### PR TITLE
Support Typescript

### DIFF
--- a/syntaxes/styled-components.json
+++ b/syntaxes/styled-components.json
@@ -4,7 +4,7 @@
 	"patterns": [
 		{
 			"name": "styled",
-			"begin": "(?:(?:([sS][tT][yY][lL][eE][dD])(?:<[_$[:alpha:]][_$[:alnum:]]+>){0,1}(?:(?:\\.([_$[:alpha:]][_$[:alnum:]]*))|(?:\\((['\"][_$[:alpha:]][_$[:alnum:]]*['\"])\\))|(?:\\(([_$[:alpha:]][_$\\.[:alnum:]]*)\\)))?)|(css|keyframes|injectGlobal)(?: as (?:.+))){0,1}\\s{0,1}(`)",
+			"begin": "(?:(?:([sS][tT][yY][lL][eE][dD])(?:<[_$[:alpha:]][_$[:alnum:]]+>){0,1}(?:(?:\\.([_$[:alpha:]][_$[:alnum:]]*))|(?:\\((['\"][_$[:alpha:]][_$[:alnum:]]*['\"])\\))|(?:\\(([_$[:alpha:]][_$\\.[:alnum:]]*)(?: as (?:.*)+){0,1}\\)))?)|(css|keyframes|injectGlobal))\\s{0,1}(`)",
 			"beginCaptures": {
 				"1": {
 					"name": "entity.name.function.tagged-template.js"

--- a/syntaxes/styled-components.json
+++ b/syntaxes/styled-components.json
@@ -4,7 +4,7 @@
 	"patterns": [
 		{
 			"name": "styled",
-			"begin": "(?:(?:([sS][tT][yY][lL][eE][dD])(?:(?:\\.([_$[:alpha:]][_$[:alnum:]]*))|(?:\\((['\"][_$[:alpha:]][_$[:alnum:]]*['\"])\\))|(?:\\(([_$[:alpha:]][_$\\.[:alnum:]]*)\\)))?)|(css|keyframes|injectGlobal))\\s{0,1}(`)",
+			"begin": "(?:(?:([sS][tT][yY][lL][eE][dD])(?:<[_$[:alpha:]][_$[:alnum:]]+>){0,1}(?:(?:\\.([_$[:alpha:]][_$[:alnum:]]*))|(?:\\((['\"][_$[:alpha:]][_$[:alnum:]]*['\"])\\))|(?:\\(([_$[:alpha:]][_$\\.[:alnum:]]*)\\)))?)|(css|keyframes|injectGlobal)(?: as (?:.+))){0,1}\\s{0,1}(`)",
 			"beginCaptures": {
 				"1": {
 					"name": "entity.name.function.tagged-template.js"


### PR DESCRIPTION
https://github.com/styled-components/vscode-styled-components/issues/22

I'm not 100% sure, if the regex-extension at the end of the line isn't too broad.
Right now, it will catch cases like `Button as React.ComponentClass<IButton>`.

Please review.