### PR TITLE
vscode-babel-coloring conflict to the known Issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ It should be the top result.
 
 ## Known Issues
 
+Conflict with vscode-babel-coloring extension breaks highlighting.
+
 Highlighting is broken immediately after a styled-component is returned from an arrow function:
 
     const arrowFun = (...args) => css`


### PR DESCRIPTION
Adding vscode-babel-coloring conflict to the known Issues