### PR TITLE
Mark styled contents as language:css

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,10 @@
             {
                 "injectTo": ["source.js", "source.ts", "source.jsx", "source.tsx"],
                 "scopeName": "styled",
-                "path": "./syntaxes/styled-components.json"
+                "path": "./syntaxes/styled-components.json",
+                "embeddedLanguages": {
+                    "styled": "css"
+                }
             }
         ]
     }


### PR DESCRIPTION
Fixes #33

Marks the contents of styled strings as being of language css rather than language javascript