### PR TITLE
Fix for VS Code 1.18 javascript react files

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
                 "path": "./syntaxes/css.json"
             },
             {
-                "injectTo": ["source.js", "source.ts", "source.jsx", "source.tsx"],
+                "injectTo": ["source.js", "source.ts", "source.jsx", "source.js.jsx", "source.tsx"],
                 "scopeName": "styled",
                 "path": "./syntaxes/styled-components.json",
                 "embeddedLanguages": {


### PR DESCRIPTION
**Bug**
highlighting not working for jsx files in VS Code 1.18

**Fix**
Make sure we grammar is also injected into the `source.js.jsx` scope

Fixes #35 
