### PR TITLE
Contribute typescript-styled-plugin to provide styled intellisense

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vscode-styled-components
 
-Syntax highlighting for [styled-components](https://github.com/styled-components/styled-components).
+Syntax highlighting and IntelliSense for [styled-components](https://github.com/styled-components/styled-components).
 
 ![Syntax highlighting in action](demo.png)
 
@@ -19,6 +19,17 @@ It should be the top result.
 [[Source](https://marketplace.visualstudio.com/items?itemName=jpoissonnier.vscode-styled-components)]
 
 ## Features
+
+* Syntax highlighting for styled components in JavaScript and TypeScript.
+* Detailed CSS IntelliSense while working in styled strings.
+* Syntax error reporting.
+
+> **❗Important**: IntelliSense and language support requires VS Code 1.20+.
+
+## Usage
+The styled-components extension adds highlighting and IntelliSense for styled-component template strings in JavaScript and TypeScript. It works out of the box when you use VS Code's built-in version of TypeScript.
+
+If you are [using a workspace version of typescript](https://code.visualstudio.com/Docs/languages/typescript#_using-newer-typescript-versions), you must currently configure the TS Server plugin manually by following [these instructions](https://github.com/Microsoft/typescript-styled-plugin#usage)
 
 ## Known Issues
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,42 @@
+{
+    "name": "vscode-styled-components",
+    "version": "0.0.10",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "typescript-styled-plugin": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/typescript-styled-plugin/-/typescript-styled-plugin-0.3.1.tgz",
+            "integrity": "sha512-oIXuSckG723q8lTprWxoYpJM6IV/x/G08U4nC0DCXGI4gMQw0ak1mjwLpRMowuD5ENELrcU6AinTpyLTREXc4A==",
+            "requires": {
+                "typescript-template-language-service-decorator": "1.1.0",
+                "vscode-css-languageservice": "2.1.11",
+                "vscode-languageserver-types": "3.5.0"
+            }
+        },
+        "typescript-template-language-service-decorator": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/typescript-template-language-service-decorator/-/typescript-template-language-service-decorator-1.1.0.tgz",
+            "integrity": "sha512-+mALyEIQTMskZJErim4wG60tBWmXwk1lyuWqZk5K1/pDC8KmmJdyeJo0Gye49cSY4P7xSsJzARuL481rnwqvbg=="
+        },
+        "vscode-css-languageservice": {
+            "version": "2.1.11",
+            "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-2.1.11.tgz",
+            "integrity": "sha1-BRrZaB1Qzu5fg6IBQsjGWagBHt4=",
+            "requires": {
+                "vscode-languageserver-types": "3.5.0",
+                "vscode-nls": "2.0.2"
+            }
+        },
+        "vscode-languageserver-types": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.5.0.tgz",
+            "integrity": "sha1-5I15li8LjgLelV4/UkkI4rGcA3Q="
+        },
+        "vscode-nls": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-2.0.2.tgz",
+            "integrity": "sha1-gIUiOAhEuK0VNJmvXDsDkhrqAto="
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
         "languages": [
             {
                 "id": "source.css.styled",
-                "aliases": ["CSS (Styled Components)"],
+                "aliases": [
+                    "CSS (Styled Components)"
+                ],
                 "configuration": "./css-styled.configuration.json"
             }
         ],
@@ -31,13 +33,27 @@
                 "path": "./syntaxes/css.json"
             },
             {
-                "injectTo": ["source.js", "source.ts", "source.jsx", "source.js.jsx", "source.tsx"],
+                "injectTo": [
+                    "source.js",
+                    "source.ts",
+                    "source.jsx",
+                    "source.js.jsx",
+                    "source.tsx"
+                ],
                 "scopeName": "styled",
                 "path": "./syntaxes/styled-components.json",
                 "embeddedLanguages": {
                     "styled": "css"
                 }
             }
+        ],
+        "typescriptServerPlugins": [
+            {
+                "name": "typescript-styled-plugin"
+            }
         ]
+    },
+    "dependencies": {
+        "typescript-styled-plugin": "^0.3.1"
     }
 }


### PR DESCRIPTION
Uses [typescript-styled-plugin](https://github.com/Microsoft/typescript-styled-plugin) to add intellisense, error reporting, and other language features for styled strings

This requires VS Code 1.20+ (current insiders builds). Users on 1.19 (the current release) will only get the intellisense only if they are working in code with a jsconfig or tsconfig project

Fixes #2
Fixes #38
Fixes https://github.com/Microsoft/typescript-styled-plugin/issues/10
