### PR TITLE
Adds rules for media functions

### DIFF
--- a/syntaxes/styled-components.json
+++ b/syntaxes/styled-components.json
@@ -100,7 +100,43 @@
 					"include": "source.css.styled"
 				}
 			]
-		}
+		},
+		{
+      "name": "media-functions",
+      "begin":
+        "([mM][eE][dD][iI][aA])\\.([[:alpha:]][[:alnum:]]*)(?:(?:\\(([`'\"].*[`'\"])\\))|(?:\\(([[:alnum:]]*)\\))|(?:\\(\\))|(?:\\((.*)\\))){0,1}\\s{0,1}(`)",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.function.tagged-template.js"
+        },
+        "2": {
+          "name": "js"
+        },
+        "3": {
+          "name": "string.js"
+        },
+        "4": {
+          "name": "constant.numeric.js"
+        },
+        "5": {
+          "name": "variable.other.object.js"
+        },
+        "6": {
+          "name": "punctuation.definition.string.template.begin.js"
+        }
+      },
+      "end": "`",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.template.end.js"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.css.styled"
+        }
+      ]
+    }
 	],
 	"scopeName": "styled"
 }

--- a/test.js
+++ b/test.js
@@ -118,3 +118,38 @@ const Link = styled.a.attrs({
 })`
   color: red;
 `
+
+// Functional Media Queries - https://www.styled-components.com/docs/advanced#media-templates
+const sizes = {
+  desktop: 992,
+  tablet: 768,
+  phone: 376,
+}
+
+const media = Object.keys(sizes).reduce((acc, label) => {
+  acc[label] = (...args) => css`
+    @media (max-width: ${sizes[label] / 16}em) {
+      ${css(...args)};
+    }
+  `
+})
+
+const mediaQuery = styled.div`
+  background: palevioletred;
+
+  ${media`
+    background: papayawhip;
+  `}
+
+  ${media.desktop`
+    background: red;
+  `};
+
+  ${media.breakAt('300px')`
+    background: palevioletred;
+  `}
+
+  ${media.desktop(400)`
+    background: coral;
+  `};
+`

--- a/test.js
+++ b/test.js
@@ -137,10 +137,6 @@ const media = Object.keys(sizes).reduce((acc, label) => {
 const mediaQuery = styled.div`
   background: palevioletred;
 
-  ${media`
-    background: papayawhip;
-  `}
-
   ${media.desktop`
     background: red;
   `};


### PR DESCRIPTION
Styled-Components suggests a functional approach for standardizing media queries. Currently this approach breaks the syntax highlighting inside all media queries. This adds multiple syntax highlights for media based functions.

The added syntax highlighting only depends on things being attached to `media`, all following properties can be freely named.

Styled-Components example: https://www.styled-components.com/docs/advanced#media-templates

![image](https://user-images.githubusercontent.com/25938649/35587063-a2ef9f28-05ca-11e8-9cdf-51cf1bc3b0c3.png)


