### PR TITLE
created attrs capture group for object and css template strings

### DIFF
--- a/syntaxes/styled-components.json
+++ b/syntaxes/styled-components.json
@@ -2,7 +2,7 @@
 	"fileTypes": ["js", "jsx", "ts", "tsx"],
 	"injectionSelector": "L:source -comment",
 	"patterns": [
-		{
+    {
 			"name": "styled",
 			"begin": "(?:(?:([sS][tT][yY][lL][eE][dD])(?:<[_$[:alpha:]][_$[:alnum:]]+>){0,1}(?:(?:\\.([_$[:alpha:]][_$[:alnum:]]*))|(?:\\((['\"][_$[:alpha:]][_$[:alnum:]]*['\"])\\))|(?:\\(([_$[:alpha:]][_$\\.[:alnum:]]*)(?: as (?:.*)+){0,1}\\)))?)|(css|keyframes|injectGlobal))\\s{0,1}(`)",
 			"beginCaptures": {
@@ -100,7 +100,117 @@
 					"include": "source.css.styled"
 				}
 			]
-		}
+    },
+    {
+      "name": "styled.attrs.object",
+      "begin": "(styled)\\.([a-z]+)\\.(attrs)\\(",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.function.tagged-template.js"
+        },
+        "2": {
+          "name": "entity.name.tag.attrs-tag.js"
+        },
+        "3": {
+          "name": "entity.name.function.tagged-template.js"
+        }
+      },
+      "end": "(?<!\\)|\\)\\s)(`)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.string.template.end.js"
+        }
+      },
+      "patterns": [
+        {
+          "name": "styled.attrs.objc",
+          "begin": "(\\{)",
+          "end": "(\\})",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.objc.start.js"
+            },
+            "2": {
+              "name": "punctuation.definition.objc.start.js"
+            }
+          },
+          "patterns": [
+            {
+              "name": "styled.attrs.object.property",
+              "match": "\\s*([$_a-zA-Z][$_a-zA-Z1-9]*):",
+              "captures": {
+                "1": {
+                  "name": "variable.parameter.object.property.js"
+                }
+              }
+            },
+            {
+              "name": "attrs.object.props",
+              "match": "(props)",
+              "captures": {
+                "1": {
+                  "name": "keyword.other.props.js"
+                }
+              }
+            },
+            {
+              "name": "attrs.object.or-operator",
+              "match": "(\\|)",
+              "captures": {
+                "1": {
+                  "name": "keyword.operator.or.js"
+                }
+              }
+            },
+            {
+              "name": "attrs.object.string.double",
+              "begin": "(\")",
+              "end": "(\")",
+              "captures": {
+                "1": {
+                  "name": "string.quoted.double.start.js"
+                },
+                "2": {
+                  "name": "string.quoted.double.end.js"
+                }
+              },
+              "contentName": "string.quoted.double.content.js"
+            },
+            {
+              "name": "attrs.object.string.single",
+              "begin": "(')",
+              "end": "(')",
+              "captures": {
+                "1": {
+                  "name": "string.quoted.single.start.js"
+                },
+                "2": {
+                  "name": "string.quoted.single.end.js"
+                }
+              },
+              "contentName": "string.quoted.double.content.js"
+            },
+            {
+              "name": "attrs.object.comment.single",
+              "begin": "(//)",
+              "end": "\\n",
+              "captures": {
+                "1": {
+                  "name": "comment.line.double-slash.js"
+                }
+              },
+              "contentName": "comment.line.double-slash.js"
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        },
+        {
+          "include": "source.css.styled"
+        }
+      ]
+    }
 	],
 	"scopeName": "styled"
 }

--- a/test.js
+++ b/test.js
@@ -1,26 +1,27 @@
 const DotTag = styled.div`
-    color: #ebebeb;
-    font-size: ${props => props.theme.fontSize};
-    font-family: Helvetica;
-    ${mixin}
-`
+  color: #ebebeb;
+  font-size: ${props => props.theme.fontSize};
+  font-family: Helvetica;
+  ${mixin};
+`;
 
-const StringTagname = styled('div')`
-    color: #ff0000;
-`
+
+const StringTagname = styled("div")`
+  color: #ff0000;
+`;
 
 const Component = styled(Component)`
-    color: #ebebeb;
-`
+  color: #ebebeb;
+`;
 
 const SegmentedComponent = styled(Segmented.Component)`
-    padding: 3px;
-`
+  padding: 3px;
+`;
 
 const mixin = css`
-    height: 20px;
-    padding: 5px;
-`
+  height: 20px;
+  padding: 5px;
+`;
 
 // const comment = css`
 //     height: 20px;
@@ -28,53 +29,52 @@ const mixin = css`
 // `
 
 const arrowFun = (...args) => css`
-    height: 12px;
-`
+  height: 12px;
+`;
 
-const test = "broken" /* Highlighting is broken after a styled-component is returned from an arrow function*/
+const test =
+  "broken"; /* Highlighting is broken after a styled-component is returned from an arrow function*/
 
 class InsideMethod extends React.Component {
-    render () {
-        return styled(Component)`
-            line-height: 21px;
-        `
-    }
+  render() {
+    return styled(Component)`
+      line-height: 21px;
+    `;
+  }
 }
 
-let variableAssignment
+let variableAssignment;
 
 variableAssignment = css`
-    height: 1px;
-`
+  height: 1px;
+`;
 
 /* expression */
 styled`
     height: 12px;
-`
-
- (styled.div`
-    height: 12px;
-`)
+`(styled.div`
+  height: 12px;
+`);
 
 export default styled(ExportComponent)`
-	max-width: 100%;
-`
+  max-width: 100%;
+`;
 
 function insideFunction() {
-    return styled.div`
-        height: 15px;
-    `
+  return styled.div`
+    height: 15px;
+  `;
 }
 
 const ObjectLiteral = {
-    styles: styled`
+  styles: styled`
         height: 12px;
         color: #000000;
-        font: ${props => 'lol'};
-        ${props => 'padding: 5px'}
-        ${props => 'border'}: 1px solid #000000;
+        font: ${props => "lol"};
+        ${props => "padding: 5px"}
+        ${props => "border"}: 1px solid #000000;
     `
-}
+};
 
 const rotate360 = keyframes`
     from {
@@ -83,38 +83,63 @@ const rotate360 = keyframes`
     to {
         transform: rotate(1turn);
     }
-`
+`;
 
 // .extend
 
-const Comp = styled.div`color: red;`
+const Comp = styled.div`
+  color: red;
+`;
 
 const NewComp = Comp.extend`
   color: green;
-`
+`;
 
 // .withComponent()
 
-const NewCompWithString = CompWithComponent.withComponent('span')`
+const NewCompWithString = CompWithComponent.withComponent("span")`
   color: green;
-`
+`;
 
-const NewCompWithStringOneLine = CompWithComponent.withComponent('span')`color: green;`
+const NewCompWithStringOneLine = CompWithComponent.withComponent(
+  "span"
+)`color: green;
+`
 
 const NewCompWithComponent = CompWithComponent.withComponent(OtherComp)`
   color: green;
-`
-
+`;
 
 // Typescript
-const Root = styled<RootProps>('div')`
-  height: ${(props) => props.label ? 72 : 48}px;
-`
+const Root =
+  styled <
+  RootProps >
+  "div"`
+  height: ${props => (props.label ? 72 : 48)}px;
+`;
 
 // SC.attrs({})
 
-const Link = styled.a.attrs({
-  target: '_blank'
+
+const Input = styled.input.attrs({
+  // we can define static props
+  type: 'password',
+
+  // or we can define dynamic ones
+  margin: props => props.size || "1em",
+  padding: props => props.size || '1em' 
 })`
-  color: red;
+  color: palevioletred;
+  font-size: 1em;
+  border: 2px solid palevioletred;
+  border-radius: 3px;
+
+  /* here we use the dynamically computed props */
+  margin: ${props => props.margin};
+  padding: ${props => props.padding};
 `
+
+
+const Input = styled.input.attrs({ type: 'password'})`
+  color: red;
+  `


### PR DESCRIPTION
So this is what I think is a good implementation for the `attrs` support. I am by no means an expert at vscode extensions and I am not at all attached to how I colored the object that was captured, I did my best to make it reasonable. 

This is broadly what the capture group does...

1.  begins with `styled.<any tag>.attrs(`
2. ends with any template string element that isn't preceded by a `)`
3. captures the object surrounded by  { } and attempts to reasonably style it.
4. anything not captured is the domain of the css and is styled how the `source.css.styled` recommends

Things that are not currently working great but I don't think will be an issue. But I can work on it if you feel like its needed.

1. Inside the object you can have single line comments but not block comments. I thought that would be reasonable but if you really want block commenting let me know and it shouldn't be too hard to add

2. I couldn't figure out how to use the object capture I created to again capture the objects that might exist inside my object. I don't think this will be a huge issue because I don't know when you are putting objects inside the `attrs` object, but I can also work on it if you think its necessary for implementation. An object in the object breaks the rest of the objects highlighting, not the highlighting of the css.

3. So I could not for the life of me figure out how to make sure that the object gets styled how every other object for the javascript language gets styled. Maybe there is some source I am supposed to include but I couldn't find it. Ended up styling the object by hand, but if there is a way to do something like `"patterns": [ {"include": "#object:"} ]` and have it be consistent with how vscode styles the objects outside of styled components I'm all ears.

This is my first every pull request so if I have done something horribly taboo or offensive let me know and I'm very sorry.