### PR TITLE
Updated attrs support

### DIFF
--- a/syntaxes/styled-components.json
+++ b/syntaxes/styled-components.json
@@ -139,7 +139,7 @@
         },
         {
             "name": "styled.attrs.object",
-            "begin": "(styled)\\.([a-z]+)\\.(attrs)\\(",
+            "begin": "([sS][tT][yY][lL][eE][dD])\\.([[:alpha:]]+)\\.(attrs)\\(",
             "beginCaptures": {
                 "1": {
                     "name": "entity.name.function.tagged-template.js"
@@ -173,7 +173,7 @@
                         "patterns": [
                             {
                                 "name": "styled.attrs.object.property",
-                                "match": "\\s*([$_a-zA-Z][$_a-zA-Z1-9]*):",
+                                "match": "\\s*([$_[:alpha]]*[$_[:alnum:]]*):",
                                 "captures": {
                                     "1": {
                                         "name": "variable.parameter.object.property.js"

--- a/syntaxes/styled-components.json
+++ b/syntaxes/styled-components.json
@@ -102,41 +102,152 @@
 			]
 		},
 		{
-      "name": "media-functions",
-      "begin":
-        "([mM][eE][dD][iI][aA])\\.([[:alpha:]][[:alnum:]]*)(?:(?:\\(([`'\"].*[`'\"])\\))|(?:\\(([[:alnum:]]*)\\))|(?:\\(\\))|(?:\\((.*)\\))){0,1}\\s{0,1}(`)",
-      "beginCaptures": {
-        "1": {
-          "name": "entity.name.function.tagged-template.js"
+            "name": "media-functions",
+            "begin":
+            "([mM][eE][dD][iI][aA])\\.([[:alpha:]][[:alnum:]]*)(?:(?:\\(([`'\"].*[`'\"])\\))|(?:\\(([[:alnum:]]*)\\))|(?:\\(\\))|(?:\\((.*)\\))){0,1}\\s{0,1}(`)",
+            "beginCaptures": {
+                "1": {
+                    "name": "entity.name.function.tagged-template.js"
+                },
+                "2": {
+                    "name": "js"
+                },
+                "3": {
+                    "name": "string.js"
+                },
+                "4": {
+                    "name": "constant.numeric.js"
+                },
+                "5": {
+                    "name": "variable.other.object.js"
+                },
+                "6": {
+                    "name": "punctuation.definition.string.template.begin.js"
+                }
+            },
+            "end": "`",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.template.end.js"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "source.css.styled"
+                }
+            ]
         },
-        "2": {
-          "name": "js"
-        },
-        "3": {
-          "name": "string.js"
-        },
-        "4": {
-          "name": "constant.numeric.js"
-        },
-        "5": {
-          "name": "variable.other.object.js"
-        },
-        "6": {
-          "name": "punctuation.definition.string.template.begin.js"
-        }
-      },
-      "end": "`",
-      "endCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.template.end.js"
-        }
-      },
-      "patterns": [
         {
-          "include": "source.css.styled"
-        }
-      ]
+            "name": "styled.attrs.object",
+            "begin": "(styled)\\.([a-z]+)\\.(attrs)\\(",
+            "beginCaptures": {
+                "1": {
+                    "name": "entity.name.function.tagged-template.js"
+                },
+                "2": {
+                    "name": "entity.name.tag.attrs-tag.js"
+                },
+                "3": {
+                    "name": "entity.name.function.tagged-template.js"
+                }
+            },
+            "end": "(?<!\\)|\\)\\s)(`)",
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.definition.string.template.end.js"
+                }
+            },
+            "patterns": [
+                {
+                    "name": "styled.attrs.objc",
+                    "begin": "(\\{)",
+                        "end": "(\\})",
+                        "captures": {
+                            "1": {
+                                "name": "punctuation.definition.objc.start.js"
+                            },
+                            "2": {
+                                "name": "punctuation.definition.objc.start.js"
+                            }
+                        },
+                        "patterns": [
+                            {
+                                "name": "styled.attrs.object.property",
+                                "match": "\\s*([$_a-zA-Z][$_a-zA-Z1-9]*):",
+                                "captures": {
+                                    "1": {
+                                        "name": "variable.parameter.object.property.js"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "attrs.object.props",
+                                "match": "(props)",
+                                "captures": {
+                                    "1": {
+                                        "name": "keyword.other.props.js"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "attrs.object.or-operator",
+                                "match": "(\\|)",
+                                "captures": {
+                                    "1": {
+                                        "name": "keyword.operator.or.js"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "attrs.object.string.double",
+                                "begin": "(\")",
+                                "end": "(\")",
+                                "captures": {
+                                    "1": {
+                                        "name": "string.quoted.double.start.js"
+                                    },
+                                    "2": {
+                                        "name": "string.quoted.double.end.js"
+                                    }
+                                },
+                                "contentName": "string.quoted.double.content.js"
+                            },
+                            {
+                                "name": "attrs.object.string.single",
+                                "begin": "(')",
+                                "end": "(')",
+                                "captures": {
+                                    "1": {
+                                        "name": "string.quoted.single.start.js"
+                                    },
+                                    "2": {
+                                        "name": "string.quoted.single.end.js"
+                                    }
+                                },
+                                "contentName": "string.quoted.double.content.js"
+                            },
+                            {
+                                "name": "attrs.object.comment.single",
+                                "begin": "(//)",
+                                "end": "\\n",
+                                "captures": {
+                                    "1": {
+                                        "name": "comment.line.double-slash.js"
+                                    }
+                                },
+                                "contentName": "comment.line.double-slash.js"
+                            },
+                            {
+                                "include": "$self"
+                            }
+                        ]
+                    },
+                    {
+                        "include": "source.css.styled"
+                    }
+                ]
+            }   
+        ],
+        "scopeName": "styled"
     }
-	],
-	"scopeName": "styled"
-}
+    

--- a/syntaxes/styled-components.json
+++ b/syntaxes/styled-components.json
@@ -138,7 +138,7 @@
             ]
         },
         {
-            "name": "styled.attrs.object",
+            "name": "styled.attrs.all",
             "begin": "([sS][tT][yY][lL][eE][dD])\\.([[:alpha:]]+)\\.(attrs)\\(",
             "beginCaptures": {
                 "1": {
@@ -159,95 +159,94 @@
             },
             "patterns": [
                 {
-                    "name": "styled.attrs.objc",
+                    "name": "styled.attrs.object",
                     "begin": "(\\{)",
-                        "end": "(\\})",
-                        "captures": {
-                            "1": {
-                                "name": "punctuation.definition.objc.start.js"
-                            },
-                            "2": {
-                                "name": "punctuation.definition.objc.start.js"
+                    "end": "(\\})",
+                    "captures": {
+                        "1": {
+                            "name": "punctuation.definition.objc.start.js"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.objc.start.js"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "name": "styled.attrs.object.property",
+                            "match": "\\s*([$_[:alpha]]*[$_[:alnum:]]*):",
+                            "captures": {
+                                "1": {
+                                    "name": "variable.parameter.object.property.js"
+                                }
                             }
                         },
-                        "patterns": [
-                            {
-                                "name": "styled.attrs.object.property",
-                                "match": "\\s*([$_[:alpha]]*[$_[:alnum:]]*):",
-                                "captures": {
-                                    "1": {
-                                        "name": "variable.parameter.object.property.js"
-                                    }
+                        {
+                            "name": "styled.attrs.object.props",
+                            "match": "(props)",
+                            "captures": {
+                                "1": {
+                                    "name": "keyword.other.props.js"
                                 }
-                            },
-                            {
-                                "name": "attrs.object.props",
-                                "match": "(props)",
-                                "captures": {
-                                    "1": {
-                                        "name": "keyword.other.props.js"
-                                    }
-                                }
-                            },
-                            {
-                                "name": "attrs.object.or-operator",
-                                "match": "(\\|)",
-                                "captures": {
-                                    "1": {
-                                        "name": "keyword.operator.or.js"
-                                    }
-                                }
-                            },
-                            {
-                                "name": "attrs.object.string.double",
-                                "begin": "(\")",
-                                "end": "(\")",
-                                "captures": {
-                                    "1": {
-                                        "name": "string.quoted.double.start.js"
-                                    },
-                                    "2": {
-                                        "name": "string.quoted.double.end.js"
-                                    }
-                                },
-                                "contentName": "string.quoted.double.content.js"
-                            },
-                            {
-                                "name": "attrs.object.string.single",
-                                "begin": "(')",
-                                "end": "(')",
-                                "captures": {
-                                    "1": {
-                                        "name": "string.quoted.single.start.js"
-                                    },
-                                    "2": {
-                                        "name": "string.quoted.single.end.js"
-                                    }
-                                },
-                                "contentName": "string.quoted.double.content.js"
-                            },
-                            {
-                                "name": "attrs.object.comment.single",
-                                "begin": "(//)",
-                                "end": "\\n",
-                                "captures": {
-                                    "1": {
-                                        "name": "comment.line.double-slash.js"
-                                    }
-                                },
-                                "contentName": "comment.line.double-slash.js"
-                            },
-                            {
-                                "include": "$self"
                             }
-                        ]
-                    },
-                    {
-                        "include": "source.css.styled"
-                    }
-                ]
-            }   
-        ],
-        "scopeName": "styled"
-    }
-    
+                        },
+                        {
+                            "name": "styled.attrs.object.or-operator",
+                            "match": "(\\|)",
+                            "captures": {
+                                "1": {
+                                    "name": "keyword.operator.or.js"
+                                }
+                            }
+                        },
+                        {
+                            "name": "styled.attrs.object.string.double",
+                            "begin": "(\")",
+                            "end": "(\")",
+                            "captures": {
+                                "1": {
+                                    "name": "string.quoted.double.start.js"
+                                },
+                                "2": {
+                                    "name": "string.quoted.double.end.js"
+                                }
+                            },
+                            "contentName": "string.quoted.double.content.js"
+                        },
+                        {
+                            "name": "styled.attrs.object.string.single",
+                            "begin": "(')",
+                            "end": "(')",
+                            "captures": {
+                                "1": {
+                                    "name": "string.quoted.single.start.js"
+                                },
+                                "2": {
+                                    "name": "string.quoted.single.end.js"
+                                }
+                            },
+                            "contentName": "string.quoted.single.content.js"
+                        },
+                        {
+                            "name": "styled.attrs.object.comment.single",
+                            "begin": "(//)",
+                            "end": "\\n",
+                            "captures": {
+                                "1": {
+                                    "name": "comment.line.double-slash.js"
+                                }
+                            },
+                            "contentName": "comment.line.double-slash.js"
+                        },
+                        {
+                            "include": "$self"
+                        }
+                    ]
+                },
+                {
+                    "include": "source.css.styled"
+                }
+            ]
+        }   
+    ],
+    "scopeName": "styled"
+}

--- a/test.js
+++ b/test.js
@@ -133,6 +133,23 @@ const media = Object.keys(sizes).reduce((acc, label) => {
     }
   `
 })
+const Input = styled.input.attrs({
+  // we can define static props
+  type: 'password',
+
+  // or we can define dynamic ones
+  margin: props => props.size || '1em',
+  padding: props => props.size || '1em'
+})`
+  color: palevioletred;
+  font-size: 1em;
+  border: 2px solid palevioletred;
+  border-radius: 3px;
+
+  /* here we use the dynamically computed props */
+  margin: ${props => props.margin};
+  padding: ${props => props.padding};
+`;
 
 const mediaQuery = styled.div`
   background: palevioletred;
@@ -149,3 +166,50 @@ const mediaQuery = styled.div`
     background: coral;
   `};
 `
+const Input = styled.input.attrs({
+  // we can define static props
+  type: 'password',
+
+  // or we can define dynamic ones
+  margin: props => props.size || '1em',
+  padding: props => props.size || '1em'
+})`
+  color: palevioletred;
+  font-size: 1em;
+  border: 2px solid palevioletred;
+  border-radius: 3px;
+
+  /* here we use the dynamically computed props */
+  margin: ${props => props.margin};
+  padding: ${props => props.padding};
+`;
+
+const Input = styled.input.attrs({
+  // we can define static props
+  type: 'password',
+
+  // or we can define dynamic ones
+  margin: props => props.size || '1em',
+  padding: props => props.size || '1em'
+})`
+  color: palevioletred;
+  font-size: 1em;
+  border: 2px solid palevioletred;
+  border-radius: 3px;
+
+  ${media.desktop`
+    background: red;
+  `};
+
+  ${media.breakAt('300px')`
+    background: palevioletred;
+  `}
+
+  ${media.desktop(400)`
+    background: coral;
+  `};
+
+  /* here we use the dynamically computed props */
+  margin: ${props => props.margin};
+  padding: ${props => props.padding};
+`;


### PR DESCRIPTION
So this is what I think is a good implementation for the attrs support. I am by no means an expert at vscode extensions and I am not at all attached to how I colored the object that was captured, I did my best to make it reasonable.

This is broadly what the capture group does...

    begins with styled.<any tag>.attrs(
    ends with any template string element that isn't preceded by a )
    captures the object surrounded by { } and attempts to reasonably style it.
    anything not captured is the domain of the css and is styled how the source.css.styled recommends

Things that are not currently working great but I don't think will be an issue. But I can work on it if you feel like its needed.

    Inside the object you can have single line comments but not block comments. I thought that would be reasonable but if you really want block commenting let me know and it shouldn't be too hard to add

    I couldn't figure out how to use the object capture I created to again capture the objects that might exist inside my object. I don't think this will be a huge issue because I don't know when you are putting objects inside the attrs object, but I can also work on it if you think its necessary for implementation. An object in the object breaks the rest of the objects highlighting, not the highlighting of the css.

    So I could not for the life of me figure out how to make sure that the object gets styled how every other object for the javascript language gets styled. Maybe there is some source I am supposed to include but I couldn't find it. Ended up styling the object by hand, but if there is a way to do something like "patterns": [ {"include": "#object:"} ] and have it be consistent with how vscode styles the objects outside of styled components I'm all ears.

This is my first every pull request so if I have done something horribly taboo or offensive let me know and I'm very sorry.