### PR TITLE
Pick up styled plugin 0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,31 +1,38 @@
 {
     "name": "vscode-styled-components",
-    "version": "0.0.12",
+    "version": "0.0.14",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
         "typescript-styled-plugin": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/typescript-styled-plugin/-/typescript-styled-plugin-0.3.1.tgz",
-            "integrity": "sha512-oIXuSckG723q8lTprWxoYpJM6IV/x/G08U4nC0DCXGI4gMQw0ak1mjwLpRMowuD5ENELrcU6AinTpyLTREXc4A==",
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/typescript-styled-plugin/-/typescript-styled-plugin-0.5.1.tgz",
+            "integrity": "sha512-gGyxbWaClzKxFkVx5Y6wmUDvfk50H0XuM05JC7zWF/FQsjUizgJkYXgdTh2XwLP43tXkgZtqdmDrLgNGozXJRA==",
             "requires": {
-                "typescript-template-language-service-decorator": "1.1.0",
-                "vscode-css-languageservice": "2.1.11",
+                "typescript-template-language-service-decorator": "1.2.0",
+                "vscode-css-languageservice": "3.0.6",
                 "vscode-languageserver-types": "3.5.0"
             }
         },
         "typescript-template-language-service-decorator": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/typescript-template-language-service-decorator/-/typescript-template-language-service-decorator-1.1.0.tgz",
-            "integrity": "sha512-+mALyEIQTMskZJErim4wG60tBWmXwk1lyuWqZk5K1/pDC8KmmJdyeJo0Gye49cSY4P7xSsJzARuL481rnwqvbg=="
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/typescript-template-language-service-decorator/-/typescript-template-language-service-decorator-1.2.0.tgz",
+            "integrity": "sha512-rF0jrvpYn6Ec2jnxBHF1st/HEl84LV7od8872o82zHgKEU1vFhT4x6fvuLi5UD0gl2gKv3zSefG18DoeUHE7ig=="
         },
         "vscode-css-languageservice": {
-            "version": "2.1.11",
-            "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-2.1.11.tgz",
-            "integrity": "sha1-BRrZaB1Qzu5fg6IBQsjGWagBHt4=",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-3.0.6.tgz",
+            "integrity": "sha512-gHC0AvWUgSHOVVuJFmupgZaBeAisfw3UL5GqBKS2+M6dwvEinEScyTEaI3rEWGSdlshKy65p1oW8ifsJtcFTYw==",
             "requires": {
-                "vscode-languageserver-types": "3.5.0",
+                "vscode-languageserver-types": "3.6.0-next.1",
                 "vscode-nls": "2.0.2"
+            },
+            "dependencies": {
+                "vscode-languageserver-types": {
+                    "version": "3.6.0-next.1",
+                    "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.6.0-next.1.tgz",
+                    "integrity": "sha512-n4G+hCgZwAhtcJSCkwJP153TLdcEBWwrIrb3Su/SpOkhmU7KjDgxaQBLA45hf+QbhB8uKQb+TVStPvbuYFHSMA=="
+                }
             }
         },
         "vscode-languageserver-types": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
         ]
     },
     "dependencies": {
-        "typescript-styled-plugin": "^0.3.1"
+        "typescript-styled-plugin": "^0.5.1"
     }
 }


### PR DESCRIPTION
Picks up version 0.5.1 of the typescript styled plugin. This update brings a number of important bug fixes and also adds quick fixes for misspelled properties:

![screen shot 2018-02-13 at 12 52 16 pm](https://user-images.githubusercontent.com/12821956/36173090-bd14bab2-10bc-11e8-91fe-2c49468caed2.png)
