### PR TITLE
Add support for emotion-style TypeScript declarations

### DIFF
--- a/syntaxes/styled-components.json
+++ b/syntaxes/styled-components.json
@@ -4,7 +4,7 @@
 	"patterns": [
 		{
             "contentName": "source.css.scss",
-            "begin": "(?:([sS][tT][yY][lL][eE][dD](?:<[_$[:alpha:]][_$[:alnum:]]+>)?(?:\\.[_$[:alpha:]][_$[:alnum:]]*|\\(['\"][_$[:alpha:]][_$[:alnum:]]*['\"]\\)|\\([_$[:alpha:]][_$\\.[:alnum:]]*(?:\\s+as\\s+.*?)?\\)))|(css|keyframes|injectGlobal))\\s*(`)",
+            "begin": "(?:([sS][tT][yY][lL][eE][dD](?:<[_$[:alpha:]][_$[[:alnum:][, '\"]]]+>)?(?:\\.[_$[:alpha:]][_$[:alnum:]]*|\\(['\"][_$[:alpha:]][_$[:alnum:]]*['\"]\\)|\\([_$[:alpha:]][_$\\.[:alnum:]]*(?:\\s+as\\s+.*?)?\\)))|(css|keyframes|injectGlobal))\\s*(`)",
 			"beginCaptures": {
                 "1": {
                     "name": "entity.name.function.tagged-template.ts",

--- a/test.js
+++ b/test.js
@@ -107,6 +107,12 @@ const Root = styled<RootProps>('div')`
   height: ${(props) => props.label ? 72 : 48}px;
 `
 
+// Typescript, Emotion
+const Container = styled<ContainerProps, 'div'>('div')`
+  height: 50px;
+  display: ${(props) => props.display};
+`
+
 // SC.attrs({})
 
 const Link = styled.a.attrs({


### PR DESCRIPTION
This makes a slight adjustment to the regex to support Emotion in TypeScript.

For some background, the [TypeScript docs for Emotion](https://github.com/emotion-js/emotion/blob/master/docs/typescript.md#passing-props) state that "Unfortunately, you will need to pass a second parameter with the tag name because TypeScript is unable to infer the tagname." I assume this issue doesn't affect styled-components.

Before:
![Emotion without CSS syntax highlighting](https://user-images.githubusercontent.com/88163/36449675-4e631bde-1640-11e8-84be-bb05f55a0bcf.png)

After:
![Emotion with CSS syntax highlighting](https://user-images.githubusercontent.com/88163/36449681-52f1b912-1640-11e8-96a5-23455da3dbda.png)

I've also added an example to the `test.js` file. As Beyoncé (probably) said: "If you liked it, then you should have put a ~~ring~~ test on it."
