### PR TITLE
Do not inject grammar into strings

### DIFF
--- a/syntaxes/styled-components.json
+++ b/syntaxes/styled-components.json
@@ -1,6 +1,6 @@
 {
 	"fileTypes": ["js", "jsx", "ts", "tsx"],
-	"injectionSelector": "L:source -comment",
+	"injectionSelector": "L:source -comment -string",
 	"patterns": [
 		{
             "contentName": "source.css.scss",


### PR DESCRIPTION
The grammar for highlighting CSS was previously injected into all grammatical scopes except for comments. Since it doesn't make sense in strings of any kind either, this PR disable the injection into those scopes.

In particular this fixes #65.