### PR TITLE
Enable injection for <component>.extend.attrs.

### DIFF
--- a/syntaxes/styled-components.json
+++ b/syntaxes/styled-components.json
@@ -125,7 +125,7 @@
             ]
         },
         {
-            "begin": "([sS][tT][yY][lL][eE][dD](?:<[_$[:alpha:]][_$[:alnum:]]+>)?(?:\\.[_$[:alpha:]][_$[:alnum:]]*|\\(['\"][_$[:alpha:]][_$[:alnum:]]*['\"]\\)|\\([_$[:alpha:]][_$\\.[:alnum:]]*(?:\\s+as\\s+.*?)?\\)))(?=\\.attrs\\s*\\()",
+            "begin": "(?:([sS][tT][yY][lL][eE][dD](?:<[_$[:alpha:]][_$[:alnum:]]+>)?(?:\\.[_$[:alpha:]][_$[:alnum:]]*|\\(['\"][_$[:alpha:]][_$[:alnum:]]*['\"]\\)|\\([_$[:alpha:]][_$\\.[:alnum:]]*(?:\\s+as\\s+.*?)?\\)))|(\\.)(extend))(?=\\.attrs\\s*\\()",
             "beginCaptures": {
                 "1": {
                     "name": "entity.name.function.tagged-template.ts",
@@ -140,6 +140,12 @@
                             "include": "source.ts#expression"
                         }
                     ]
+                },
+                "2": {
+                    "name": "punctuation.accessor.js"
+                },
+				"3": {
+					"name": "entity.name.function.tagged-template.js"
                 }
             },
             "end": "(?<!\\G)(?<=`)",


### PR DESCRIPTION
This PR makes the injection grammar trigger on `Component.extend.attrs` scenarios.

It fixes #63.