### PR TITLE
Handle .extend in withComponent rule. Fixes #75

### DIFF
--- a/syntaxes/styled-components.json
+++ b/syntaxes/styled-components.json
@@ -67,7 +67,7 @@
 		},
 		{
             "contentName": "source.css.scss",
-			"begin": "([_$[:alpha:]][_$[:alnum:]]*\\.withComponent\\((?:['\"][_$[:alpha:]][_$[:alnum:]]*['\"]|[_$[:alpha:]][_$\\.[:alnum:]]*)\\))\\s*(`)",
+			"begin": "([_$[:alpha:]][_$[:alnum:]]*\\.withComponent\\((?:['\"][_$[:alpha:]][_$[:alnum:]]*['\"]|[_$[:alpha:]][_$\\.[:alnum:]]*)\\))\\s*(?:(\\.)(extend))?(`)",
 			"beginCaptures": {
                 "1": {
                     "name": "entity.name.function.tagged-template.ts",
@@ -77,7 +77,13 @@
                         }
                     ]
                 },
-				"2": {
+                "2": {
+                    "name": "punctuation.accessor.js"
+                },
+				"3": {
+					"name": "entity.name.function.tagged-template.js variable.other.property.js"
+				},
+				"4": {
 					"name": "punctuation.definition.string.template.begin.js string.template.js"
 				}
 			},

--- a/test.js
+++ b/test.js
@@ -91,6 +91,10 @@ const NewComp = Comp.extend`
 
 // .withComponent()
 
+const NewCompWithString = CompWithComponent.withComponent('span').extend`
+  color: green;
+`
+
 const NewCompWithString = CompWithComponent.withComponent('span')`
   color: green;
 `


### PR DESCRIPTION
For some weird reason a scope from the official JS grammar fails to end a scope when using `.extend` after a function call. This caused #75.

Since I can't seem to reconcile the rule with the official grammar without changing that, I'm handling `extend` in the `withComponent` rule which avoids this issue.