### PR TITLE
Use correct package.json categories

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "vscode": "^1.5.0"
     },
     "categories": [
-        "Languages"
+        "Programming Languages"
     ],
     "contributes": {
         "languages": [


### PR DESCRIPTION
`Languages` is for language packs. Programming languages should use the "Programming Languages" category instead