### PR TITLE
Use case insensitive tm grammar matching instead of character classes

### DIFF
--- a/syntaxes/styled-components.json
+++ b/syntaxes/styled-components.json
@@ -4,7 +4,7 @@
 	"patterns": [
 		{
 			"contentName": "source.css.scss",
-			"begin": "(?:([sS][tT][yY][lL][eE][dD](?:<[_$[:alpha:]][_$[[:alnum:][, '\"]]]+>)?(?:\\.[_$[:alpha:]][_$[:alnum:]]*|\\(['\"][_$[:alpha:]][_$[:alnum:]]*['\"]\\)|\\([_$[:alpha:]][_$\\.[:alnum:]]*(?:\\s+as\\s+.*?)?\\)))|(css|keyframes|injectGlobal))\\s*(`)",
+			"begin": "(?:((?i:styled)(?:<[_$[:alpha:]][_$[[:alnum:][, '\"]]]+>)?(?:\\.[_$[:alpha:]][_$[:alnum:]]*|\\(['\"][_$[:alpha:]][_$[:alnum:]]*['\"]\\)|\\([_$[:alpha:]][_$\\.[:alnum:]]*(?:\\s+as\\s+.*?)?\\)))|(css|keyframes|injectGlobal))\\s*(`)",
 			"beginCaptures": {
 				"1": {
 					"name": "entity.name.function.tagged-template.ts",
@@ -13,7 +13,7 @@
 							"include": "source.ts#function-call"
 						},
 						{
-							"match": "[sS][tT][yY][lL][eE][dD]"
+							"match": "(?i:styled)"
 						},
 						{
 							"include": "source.ts#expression"
@@ -131,7 +131,7 @@
 			]
 		},
 		{
-			"begin": "(?:([sS][tT][yY][lL][eE][dD](?:<[_$[:alpha:]][_$[:alnum:]]+>)?(?:\\.[_$[:alpha:]][_$[:alnum:]]*|\\(['\"][_$[:alpha:]][_$[:alnum:]]*['\"]\\)|\\([_$[:alpha:]][_$\\.[:alnum:]]*(?:\\s+as\\s+.*?)?\\)))|(\\.)(extend))(?=\\.attrs\\s*\\()",
+			"begin": "(?:((?i:styled)(?:<[_$[:alpha:]][_$[:alnum:]]+>)?(?:\\.[_$[:alpha:]][_$[:alnum:]]*|\\(['\"][_$[:alpha:]][_$[:alnum:]]*['\"]\\)|\\([_$[:alpha:]][_$\\.[:alnum:]]*(?:\\s+as\\s+.*?)?\\)))|(\\.)(extend))(?=\\.attrs\\s*\\()",
 			"beginCaptures": {
 				"1": {
 					"name": "entity.name.function.tagged-template.ts",
@@ -140,7 +140,7 @@
 							"include": "source.ts#function-call"
 						},
 						{
-							"match": "[sS][tT][yY][lL][eE][dD]"
+							"match": "(?i:styled)"
 						},
 						{
 							"include": "source.ts#expression"


### PR DESCRIPTION
You can use `(?i:...)` for case insensitive matches in tm grammars. Just makes the grammar slightly more readable