### PR TITLE
Try making highlighting of template tag more consistent with other tagged templates

### DIFF
--- a/syntaxes/styled-components.json
+++ b/syntaxes/styled-components.json
@@ -7,14 +7,7 @@
 			"begin": "(?:([sS][tT][yY][lL][eE][dD](?:<[_$[:alpha:]][_$[[:alnum:][, '\"]]]+>)?(?:\\.[_$[:alpha:]][_$[:alnum:]]*|\\(['\"][_$[:alpha:]][_$[:alnum:]]*['\"]\\)|\\([_$[:alpha:]][_$\\.[:alnum:]]*(?:\\s+as\\s+.*?)?\\)))|(css|keyframes|injectGlobal))\\s*(`)",
 			"beginCaptures": {
 				"1": {
-					"name": "entity.name.function.tagged-template.ts",
 					"patterns": [
-						{
-							"include": "source.ts#function-call"
-						},
-						{
-							"match": "[sS][tT][yY][lL][eE][dD]"
-						},
 						{
 							"include": "source.ts#expression"
 						}
@@ -70,7 +63,6 @@
 			"begin": "([_$[:alpha:]][_$[:alnum:]]*\\.withComponent\\((?:['\"][_$[:alpha:]][_$[:alnum:]]*['\"]|[_$[:alpha:]][_$\\.[:alnum:]]*)\\))\\s*(?:(\\.)(extend))?(`)",
 			"beginCaptures": {
 				"1": {
-					"name": "entity.name.function.tagged-template.ts",
 					"patterns": [
 						{
 							"include": "source.ts#expression"
@@ -104,11 +96,7 @@
 			"begin": "([mM][eE][dD][iI][aA]\\.[[:alpha:]][[:alnum:]]*(?:\\(.*?\\))?)\\s*(`)",
 			"beginCaptures": {
 				"1": {
-					"name": "entity.name.function.tagged-template.ts",
 					"patterns": [
-						{
-							"match": "[mM][eE][dD][iI][aA]"
-						},
 						{
 							"include": "source.ts#expression"
 						}
@@ -134,14 +122,7 @@
 			"begin": "(?:([sS][tT][yY][lL][eE][dD](?:<[_$[:alpha:]][_$[:alnum:]]+>)?(?:\\.[_$[:alpha:]][_$[:alnum:]]*|\\(['\"][_$[:alpha:]][_$[:alnum:]]*['\"]\\)|\\([_$[:alpha:]][_$\\.[:alnum:]]*(?:\\s+as\\s+.*?)?\\)))|(\\.)(extend))(?=\\.attrs\\s*\\()",
 			"beginCaptures": {
 				"1": {
-					"name": "entity.name.function.tagged-template.ts",
 					"patterns": [
-						{
-							"include": "source.ts#function-call"
-						},
-						{
-							"match": "[sS][tT][yY][lL][eE][dD]"
-						},
 						{
 							"include": "source.ts#expression"
 						}


### PR DESCRIPTION
Fixes #110

Removes some of the top level `entity.name.function.tagged-template.ts` scopes that were being applied to the entire template tag expression. Also removes some of the special cases being applied to keywords