### PR TITLE
Pick up styled plugin 0.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,12 +27,12 @@
             "dev": true
         },
         "typescript-styled-plugin": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/typescript-styled-plugin/-/typescript-styled-plugin-0.12.0.tgz",
-            "integrity": "sha512-dqetvWmgwkfeUNyWlGlolnAw/A65bj+9I33MFQcy7a6JslZ71Zhvp0HMLmLYgF24qk5J8/UIGcYYUh7lJZIpLQ==",
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/typescript-styled-plugin/-/typescript-styled-plugin-0.13.0.tgz",
+            "integrity": "sha512-GGMzv/JAd4S8mvWgHZslvW2G1HHrdurrp93oSR4h85SM8e5at7+KCqHsZICiTaL+iN25YGkJqoaZe4XklA76rg==",
             "requires": {
                 "typescript-template-language-service-decorator": "^2.0.0",
-                "vscode-css-languageservice": "^3.0.11",
+                "vscode-css-languageservice": "^3.0.12",
                 "vscode-emmet-helper": "1.2.11",
                 "vscode-languageserver-types": "^3.13.0"
             }
@@ -43,9 +43,9 @@
             "integrity": "sha512-wbrje6G8t+h/xBRP+gyAXYpR0+U7the2YnfsF59SKz//gdLnpL+cSFhIuW61I07XXDyU68yMBFqUzm0Hg1Xpcg=="
         },
         "vscode-css-languageservice": {
-            "version": "3.0.11",
-            "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-3.0.11.tgz",
-            "integrity": "sha512-XweDpjcD+VMguJMcr5V1OHE3GclVWJ7DpojpxrlsGCJlUumY/Xrv4VcMta6z7wUBwsmOeyogT5Hf/L2SzBg6Jw==",
+            "version": "3.0.12",
+            "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-3.0.12.tgz",
+            "integrity": "sha512-+FLQ9LcukIhnxaGTjDOqb3Nb1hesz9BLXf5yeoZxUsuK7joADPLPdxLwlZugFcMAvgmtnaFIGnzkQhGOVqf5yw==",
             "requires": {
                 "vscode-languageserver-types": "^3.13.0",
                 "vscode-nls": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     ]
   },
   "dependencies": {
-    "typescript-styled-plugin": "0.12.0"
+    "typescript-styled-plugin": "0.13.0"
   },
   "devDependencies": {
     "prettier": "^1.14.3",


### PR DESCRIPTION
Picks up 0.13.0 of the styled plugin. Changelog for this update:

- Mark color completions with the `'color'` `kindModifier`. This allows editors to render the color previews inline for suggestions

- Fix more false positive errors.