### PR TITLE
Enable with workspace TypeScript versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,6 @@ It should be the top result.
 - Detailed CSS IntelliSense while working in styled strings.
 - Syntax error reporting.
 
-> **❗Important**: IntelliSense and language support requires VS Code 1.20+.
-
 ## Usage
 
-The styled-components extension adds highlighting and IntelliSense for styled-component template strings in JavaScript and TypeScript. It works out of the box when you use VS Code's built-in version of TypeScript.
-
-If you are [using a workspace version of typescript](https://code.visualstudio.com/Docs/languages/typescript#_using-newer-typescript-versions), you must currently configure the TS Server plugin manually by following [these instructions](https://github.com/Microsoft/typescript-styled-plugin#usage)
+The styled-components extension adds highlighting and IntelliSense for styled-component template strings in JavaScript and TypeScript. See [plugin configuration](https://github.com/Microsoft/typescript-styled-plugin#configuration) for information on configuring the linter and other language features.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1572,20 +1572,20 @@
             "dev": true
         },
         "typescript-styled-plugin": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/typescript-styled-plugin/-/typescript-styled-plugin-0.13.0.tgz",
-            "integrity": "sha512-GGMzv/JAd4S8mvWgHZslvW2G1HHrdurrp93oSR4h85SM8e5at7+KCqHsZICiTaL+iN25YGkJqoaZe4XklA76rg==",
+            "version": "0.14.0",
+            "resolved": "https://registry.npmjs.org/typescript-styled-plugin/-/typescript-styled-plugin-0.14.0.tgz",
+            "integrity": "sha512-RGa+tDPr7OFd+vCEvCYwtNhQSfTFaQebHXiiSABOnjwVE/M0q3vxZcB+Ppp9UGE1PDuLJ9EQRUc7VdqTZtk+oQ==",
             "requires": {
-                "typescript-template-language-service-decorator": "^2.0.0",
-                "vscode-css-languageservice": "^3.0.12",
+                "typescript-template-language-service-decorator": "^2.2.0",
+                "vscode-css-languageservice": "^3.0.13-next.12",
                 "vscode-emmet-helper": "1.2.11",
                 "vscode-languageserver-types": "^3.13.0"
             }
         },
         "typescript-template-language-service-decorator": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/typescript-template-language-service-decorator/-/typescript-template-language-service-decorator-2.0.0.tgz",
-            "integrity": "sha512-wbrje6G8t+h/xBRP+gyAXYpR0+U7the2YnfsF59SKz//gdLnpL+cSFhIuW61I07XXDyU68yMBFqUzm0Hg1Xpcg=="
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/typescript-template-language-service-decorator/-/typescript-template-language-service-decorator-2.2.0.tgz",
+            "integrity": "sha512-xiolqt1i7e22rpqMaprPgSFVgU64u3b9n6EJlAaUYE61jumipKAdI1+O5khPlWslpTUj80YzjUKjJ2jxT0D74w=="
         },
         "unc-path-regex": {
             "version": "0.1.2",
@@ -1790,9 +1790,9 @@
             }
         },
         "vscode-css-languageservice": {
-            "version": "3.0.12",
-            "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-3.0.12.tgz",
-            "integrity": "sha512-+FLQ9LcukIhnxaGTjDOqb3Nb1hesz9BLXf5yeoZxUsuK7joADPLPdxLwlZugFcMAvgmtnaFIGnzkQhGOVqf5yw==",
+            "version": "3.0.13-next.12",
+            "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-3.0.13-next.12.tgz",
+            "integrity": "sha512-5B3NYU2DBFhbUvMuTg7kBlc9COHyr/pbR1cDzXGFwemQG8W6ERsgn+eftPHFbcug1kwBjPVSoMgtw/czKpboHQ==",
             "requires": {
                 "vscode-languageserver-types": "^3.13.0",
                 "vscode-nls": "^4.0.0"
@@ -1809,9 +1809,9 @@
             }
         },
         "vscode-languageserver-types": {
-            "version": "3.13.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.13.0.tgz",
-            "integrity": "sha512-BnJIxS+5+8UWiNKCP7W3g9FlE7fErFw0ofP5BXJe7c2tl0VeWh+nNHFbwAS2vmVC4a5kYxHBjRy0UeOtziemVA=="
+            "version": "3.14.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz",
+            "integrity": "sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A=="
         },
         "vscode-nls": {
             "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     ]
   },
   "dependencies": {
-    "typescript-styled-plugin": "0.13.0"
+    "typescript-styled-plugin": "0.14.0"
   },
   "devDependencies": {
     "prettier": "^1.14.3",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     ],
     "typescriptServerPlugins": [
       {
-        "name": "typescript-styled-plugin"
+        "name": "typescript-styled-plugin",
+        "enableForWorkspaceTypeScriptVersions": true
       }
     ]
   },


### PR DESCRIPTION
Enables the typescript plugin that provides advanced language features with workspace versions of TypeScript. Previously you had to manually install the plugin if you were using a workspace version of typescript