### PR TITLE
Add more support for typescript parameters

### DIFF
--- a/syntaxes/styled-components.json
+++ b/syntaxes/styled-components.json
@@ -4,7 +4,7 @@
   "patterns": [
     {
       "contentName": "source.css.scss",
-      "begin": "(?:([\\s\\S][sS][tT][yY][lL][eE][dD](?:<.+>(?=\\())?(?:\\.[_$[:alpha:]][_$[:alnum:]]*|\\(['\"][_$[:alpha:]][_$[:alnum:]]*['\"]\\)|\\([_$[:alpha:]][_$\\.[:alnum:]]*(?:\\s+as\\s+.*?)?\\))(?:<.+>)?)|(css|keyframes|injectGlobal|createGlobalStyle))\\s*(`)",
+      "begin": "(?:([\\s\\S][sS][tT][yY][lL][eE][dD](?:<.+>(?=\\())?(?:\\.[_$[:alpha:]][_$[:alnum:]]*|\\(['\"][_$[:alpha:]][_$[:alnum:]]*['\"]\\)|\\([_$[:alpha:]][_$\\.[:alnum:]]*(?:\\s+as\\s+.*?)?\\))(?:<.+>)?)|(css|keyframes|injectGlobal|createGlobalStyle)(?:<.+>)?)\\s*(`)",
       "beginCaptures": {
         "1": {
           "patterns": [

--- a/test/colorize-fixtures/typescript-css.ts
+++ b/test/colorize-fixtures/typescript-css.ts
@@ -1,0 +1,3 @@
+const Root = css<RootProps>`
+  height: ${props => (props.label ? 72 : 48)}px;
+`;


### PR DESCRIPTION
Specifically allowing `css`, `keyframes`,, `injectGlobal`, and `createGlobalStyle` to be able to have `<Props>` attached, similar to how support was added for `styled.tag` here: https://github.com/styled-components/vscode-styled-components/commit/102f0d87d734f16bb8ec090bcbdfcd281150f817