### PR TITLE
Add limited support for css prop

### DIFF
--- a/syntaxes/styled-components.json
+++ b/syntaxes/styled-components.json
@@ -161,6 +161,38 @@
           "include": "source.ts#expression"
         }
       ]
+    },
+    {
+      "contentName": "source.css.scss",
+      "begin": "\\s*(css)(=)(\\{)(`)",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.other.attribute-name.jsx"
+        },
+        "2": {
+          "name": "keyword.operator.assignment.jsx"
+        },
+        "3": {
+          "name": "punctuation.section.embedded.begin.jsx"
+        },
+        "4": {
+          "name": "punctuation.definition.string.template.begin.jsx string.template.js"
+        }
+      },
+      "end": "(`)(\\})\\s*",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.string.template.end.jsx string.template.js"
+        },
+        "2": {
+          "name": "punctuation.section.embedded.end.jsx"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.css.styled"
+        }
+      ]
     }
   ],
   "scopeName": "styled"

--- a/test/colorize-fixtures/css-prop.js
+++ b/test/colorize-fixtures/css-prop.js
@@ -1,0 +1,6 @@
+<div
+  css={`
+    background: papayawhip;
+    color: ${props => props.theme.colors.text};
+  `}
+/>;

--- a/test/colorize-results/css-prop_js.json
+++ b/test/colorize-results/css-prop_js.json
@@ -1,0 +1,387 @@
+[
+	{
+		"c": "<",
+		"t": "source.js meta.tag.jsx punctuation.definition.tag.jsx",
+		"r": {
+			"dark_plus": "punctuation.definition.tag: #808080",
+			"light_plus": "punctuation.definition.tag: #800000",
+			"dark_vs": "punctuation.definition.tag: #808080",
+			"light_vs": "punctuation.definition.tag: #800000",
+			"hc_black": "punctuation.definition.tag: #808080"
+		}
+	},
+	{
+		"c": "div",
+		"t": "source.js meta.tag.jsx entity.name.tag.open.jsx",
+		"r": {
+			"dark_plus": "entity.name.tag: #569CD6",
+			"light_plus": "entity.name.tag: #800000",
+			"dark_vs": "entity.name.tag: #569CD6",
+			"light_vs": "entity.name.tag: #800000",
+			"hc_black": "entity.name.tag: #569CD6"
+		}
+	},
+	{
+		"c": "  ",
+		"t": "source.js meta.tag.jsx JSXAttrs",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "css",
+		"t": "source.js meta.tag.jsx JSXAttrs entity.other.attribute-name.jsx",
+		"r": {
+			"dark_plus": "entity.other.attribute-name: #9CDCFE",
+			"light_plus": "entity.other.attribute-name: #FF0000",
+			"dark_vs": "entity.other.attribute-name: #9CDCFE",
+			"light_vs": "entity.other.attribute-name: #FF0000",
+			"hc_black": "entity.other.attribute-name: #9CDCFE"
+		}
+	},
+	{
+		"c": "=",
+		"t": "source.js meta.tag.jsx JSXAttrs keyword.operator.assignment.jsx",
+		"r": {
+			"dark_plus": "keyword.operator: #D4D4D4",
+			"light_plus": "keyword.operator: #000000",
+			"dark_vs": "keyword.operator: #D4D4D4",
+			"light_vs": "keyword.operator: #000000",
+			"hc_black": "keyword.operator: #D4D4D4"
+		}
+	},
+	{
+		"c": "{",
+		"t": "source.js meta.tag.jsx JSXAttrs punctuation.section.embedded.begin.jsx",
+		"r": {
+			"dark_plus": "punctuation.section.embedded: #569CD6",
+			"light_plus": "punctuation.section.embedded: #0000FF",
+			"dark_vs": "punctuation.section.embedded: #569CD6",
+			"light_vs": "punctuation.section.embedded: #0000FF",
+			"hc_black": "punctuation.section.embedded: #569CD6"
+		}
+	},
+	{
+		"c": "`",
+		"t": "source.js meta.tag.jsx JSXAttrs punctuation.definition.string.template.begin.jsx string.template.js",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.js meta.tag.jsx JSXAttrs source.css.scss",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "background",
+		"t": "source.js meta.tag.jsx JSXAttrs source.css.scss support.type.property-name.css",
+		"r": {
+			"dark_plus": "support.type.property-name: #9CDCFE",
+			"light_plus": "support.type.property-name: #FF0000",
+			"dark_vs": "support.type.property-name: #9CDCFE",
+			"light_vs": "support.type.property-name: #FF0000",
+			"hc_black": "support.type.property-name: #D4D4D4"
+		}
+	},
+	{
+		"c": ":",
+		"t": "source.js meta.tag.jsx JSXAttrs source.css.scss",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": " papayawhip",
+		"t": "source.js meta.tag.jsx JSXAttrs source.css.scss meta.property-values.css support.constant.color.w3c-standard-color-name.css",
+		"r": {
+			"dark_plus": "support.constant.color: #CE9178",
+			"light_plus": "support.constant.color: #0451A5",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "support.constant.color: #0451A5",
+			"hc_black": "support.constant.color: #CE9178"
+		}
+	},
+	{
+		"c": ";",
+		"t": "source.js meta.tag.jsx JSXAttrs source.css.scss punctuation.semi-colon.css",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.js meta.tag.jsx JSXAttrs source.css.scss",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "color",
+		"t": "source.js meta.tag.jsx JSXAttrs source.css.scss support.type.property-name.css",
+		"r": {
+			"dark_plus": "support.type.property-name: #9CDCFE",
+			"light_plus": "support.type.property-name: #FF0000",
+			"dark_vs": "support.type.property-name: #9CDCFE",
+			"light_vs": "support.type.property-name: #FF0000",
+			"hc_black": "support.type.property-name: #D4D4D4"
+		}
+	},
+	{
+		"c": ":",
+		"t": "source.js meta.tag.jsx JSXAttrs source.css.scss",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.js meta.tag.jsx JSXAttrs source.css.scss meta.property-values.css",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "${",
+		"t": "source.js meta.tag.jsx JSXAttrs source.css.scss meta.property-values.css entity.quasi.element.js punctuation.quasi.element.begin.js",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "props",
+		"t": "source.js meta.tag.jsx JSXAttrs source.css.scss meta.property-values.css entity.quasi.element.js meta.function.arrow.js meta.function.parameters.js variable.other.readwrite.js",
+		"r": {
+			"dark_plus": "variable: #9CDCFE",
+			"light_plus": "variable: #001080",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "variable: #9CDCFE"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.js meta.tag.jsx JSXAttrs source.css.scss meta.property-values.css entity.quasi.element.js meta.function.arrow.js",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "=>",
+		"t": "source.js meta.tag.jsx JSXAttrs source.css.scss meta.property-values.css entity.quasi.element.js meta.function.arrow.js storage.type.function.arrow.js",
+		"r": {
+			"dark_plus": "storage.type: #569CD6",
+			"light_plus": "storage.type: #0000FF",
+			"dark_vs": "storage.type: #569CD6",
+			"light_vs": "storage.type: #0000FF",
+			"hc_black": "storage.type: #569CD6"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.js meta.tag.jsx JSXAttrs source.css.scss meta.property-values.css entity.quasi.element.js variable.other.object.js",
+		"r": {
+			"dark_plus": "variable: #9CDCFE",
+			"light_plus": "variable: #001080",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "variable: #9CDCFE"
+		}
+	},
+	{
+		"c": "props",
+		"t": "source.js meta.tag.jsx JSXAttrs source.css.scss meta.property-values.css entity.quasi.element.js variable.other.object.js variable.other.object.js",
+		"r": {
+			"dark_plus": "variable: #9CDCFE",
+			"light_plus": "variable: #001080",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "variable: #9CDCFE"
+		}
+	},
+	{
+		"c": ".",
+		"t": "source.js meta.tag.jsx JSXAttrs source.css.scss meta.property-values.css entity.quasi.element.js keyword.operator.accessor.js",
+		"r": {
+			"dark_plus": "keyword.operator: #D4D4D4",
+			"light_plus": "keyword.operator: #000000",
+			"dark_vs": "keyword.operator: #D4D4D4",
+			"light_vs": "keyword.operator: #000000",
+			"hc_black": "keyword.operator: #D4D4D4"
+		}
+	},
+	{
+		"c": "theme",
+		"t": "source.js meta.tag.jsx JSXAttrs source.css.scss meta.property-values.css entity.quasi.element.js meta.property.object.js variable.other.property.js",
+		"r": {
+			"dark_plus": "variable: #9CDCFE",
+			"light_plus": "variable: #001080",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "variable: #9CDCFE"
+		}
+	},
+	{
+		"c": ".",
+		"t": "source.js meta.tag.jsx JSXAttrs source.css.scss meta.property-values.css entity.quasi.element.js keyword.operator.accessor.js",
+		"r": {
+			"dark_plus": "keyword.operator: #D4D4D4",
+			"light_plus": "keyword.operator: #000000",
+			"dark_vs": "keyword.operator: #D4D4D4",
+			"light_vs": "keyword.operator: #000000",
+			"hc_black": "keyword.operator: #D4D4D4"
+		}
+	},
+	{
+		"c": "colors",
+		"t": "source.js meta.tag.jsx JSXAttrs source.css.scss meta.property-values.css entity.quasi.element.js meta.property.object.js variable.other.property.js",
+		"r": {
+			"dark_plus": "variable: #9CDCFE",
+			"light_plus": "variable: #001080",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "variable: #9CDCFE"
+		}
+	},
+	{
+		"c": ".",
+		"t": "source.js meta.tag.jsx JSXAttrs source.css.scss meta.property-values.css entity.quasi.element.js keyword.operator.accessor.js",
+		"r": {
+			"dark_plus": "keyword.operator: #D4D4D4",
+			"light_plus": "keyword.operator: #000000",
+			"dark_vs": "keyword.operator: #D4D4D4",
+			"light_vs": "keyword.operator: #000000",
+			"hc_black": "keyword.operator: #D4D4D4"
+		}
+	},
+	{
+		"c": "text",
+		"t": "source.js meta.tag.jsx JSXAttrs source.css.scss meta.property-values.css entity.quasi.element.js meta.property.object.js variable.other.property.js",
+		"r": {
+			"dark_plus": "variable: #9CDCFE",
+			"light_plus": "variable: #001080",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "variable: #9CDCFE"
+		}
+	},
+	{
+		"c": "}",
+		"t": "source.js meta.tag.jsx JSXAttrs source.css.scss meta.property-values.css entity.quasi.element.js punctuation.quasi.element.end.js",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": ";",
+		"t": "source.js meta.tag.jsx JSXAttrs source.css.scss punctuation.semi-colon.css",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "  ",
+		"t": "source.js meta.tag.jsx JSXAttrs source.css.scss",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "`",
+		"t": "source.js meta.tag.jsx JSXAttrs punctuation.definition.string.template.end.jsx string.template.js",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "}",
+		"t": "source.js meta.tag.jsx JSXAttrs punctuation.section.embedded.end.jsx",
+		"r": {
+			"dark_plus": "punctuation.section.embedded: #569CD6",
+			"light_plus": "punctuation.section.embedded: #0000FF",
+			"dark_vs": "punctuation.section.embedded: #569CD6",
+			"light_vs": "punctuation.section.embedded: #0000FF",
+			"hc_black": "punctuation.section.embedded: #569CD6"
+		}
+	},
+	{
+		"c": "/>",
+		"t": "source.js meta.tag.jsx punctuation.definition.tag.jsx",
+		"r": {
+			"dark_plus": "punctuation.definition.tag: #808080",
+			"light_plus": "punctuation.definition.tag: #800000",
+			"dark_vs": "punctuation.definition.tag: #808080",
+			"light_vs": "punctuation.definition.tag: #800000",
+			"hc_black": "punctuation.definition.tag: #808080"
+		}
+	},
+	{
+		"c": ";",
+		"t": "source.js punctuation.terminator.statement.js",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	}
+]


### PR DESCRIPTION
This currently adds support for highlighting inside a template string on css prop. Have been unable to get standard css highlighting working inside a double quoted string.

It would be nice for this to be full featured but as it stands this could probably close #152.