### PR TITLE
npm script postinstall -> prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "format": "prettier --write '**/*.{js,jsx,md,json,css}'",
-    "postinstall": "node ./node_modules/vscode/bin/install",
+    "prepare": "node ./node_modules/vscode/bin/install",
     "test": "node ./node_modules/vscode/bin/test ./test"
   },
   "contributes": {


### PR DESCRIPTION
## What

The npm `postinstall` script runs both on local `npm install` as well as after being installed as a dependency of someone else’s project. The `prepare` script only runs on local `npm install` (and before publishing). [[npm-scripts]](https://docs.npmjs.com/misc/scripts)

## Why

`vscode` is a devDependency, not a dependency, so if someone tries to install this package as a dependency of their own, the installation fails because `./node_modules/vscode` does not exist.

## Wait, what?

I’m the maintainer of [gatsby-remark-vscode](https://github.com/andrewbranch/gatsby-remark-vscode), a plugin for the Gatsby static site system that lets blog authors harness VS Code’s syntax highlighting engine to style their code blocks. In the plugin’s [v2](https://github.com/andrewbranch/gatsby-remark-vscode/issues/64), currently under development and released in alpha, I’m encouraging users to `npm install` any language and theme packages they need directly from GitHub, provided the source is licensed appropriately. One user (@janosh) tried this method on this package (`yarn add styled-components/vscode-styled-components`), only to find that it can’t be installed since it tries unsuccessfully to set itself up for development/testing (https://github.com/andrewbranch/gatsby-remark-vscode/issues/69).