### PR TITLE
feat: support custom-at-rules

### DIFF
--- a/syntaxes/css.styled.json
+++ b/syntaxes/css.styled.json
@@ -30,6 +30,12 @@
       "include": "#at_rule_supports"
     },
     {
+      "include": "#at_rule_custom_single"
+    },
+    {
+      "include": "#at_rule_custom"
+    },
+    {
       "match": ";",
       "name": "punctuation.terminator.rule.css"
     },
@@ -323,6 +329,69 @@
         {
           "match": "\\)",
           "name": "punctuation.definition.condition.end.bracket.round.scss"
+        }
+      ]
+    },
+    "at_rule_custom_single": {
+      "begin": "(?i)(?=@[\\w-]+[^;]+;s*$)",
+      "end": "(?<=;)(?!\\G)",
+      "patterns": [
+        {
+          "begin": "(?i)\\G(@)[\\w-]+",
+          "beginCaptures": {
+            "0": {
+              "name": "keyword.control.at-rule.css"
+            },
+            "1": {
+              "name": "punctuation.definition.keyword.css"
+            }
+          },
+          "end": ";",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.terminator.rule.css"
+            }
+          },
+          "name": "meta.at-rule.header.css"
+        }
+      ]
+    },
+    "at_rule_custom": {
+      "begin": "(?i)(?=@[\\w-]+(\\s|\\(|{|/\\*|$))",
+      "end": "(?<=})(?!\\G)",
+      "patterns": [
+        {
+          "begin": "(?i)\\G(@)[\\w-]+",
+          "beginCaptures": {
+            "0": {
+              "name": "keyword.control.at-rule.css"
+            },
+            "1": {
+              "name": "punctuation.definition.keyword.css"
+            }
+          },
+          "end": "(?=\\s*[{;])",
+          "name": "meta.at-rule.header.css"
+        },
+        {
+          "begin": "{",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.section.begin.bracket.curly.css"
+            }
+          },
+          "end": "}",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.end.bracket.curly.css"
+            }
+          },
+          "name": "meta.at-rule.body.css",
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
         }
       ]
     },

--- a/test/colorize-fixtures/custom-at-rule.js
+++ b/test/colorize-fixtures/custom-at-rule.js
@@ -1,0 +1,14 @@
+const customAtRule = styled.div`
+  display: flex;
+  background-color: yellow;
+
+  @apply flex-col justify-center items-center;
+
+  @screen md {
+    @apply bg-red-300;
+  }
+
+  @screen xl {
+    background-color: red;
+  }
+`


### PR DESCRIPTION
This PR adds support for custom at-rules. Ported from [vscode/extensions/css/syntaxes/css.tmLanguage.json](https://github.com/microsoft/vscode/blob/master/extensions/css/syntaxes/css.tmLanguage.json#L608-L670)

Full support (validation with [typescript-styled-plugin](https://github.com/microsoft/typescript-styled-plugin)) depends on https://github.com/microsoft/vscode-css-languageservice/issues/214, but as far as new syntax highlighting doesn't break anything I think it can be merged without waiting for upstream.