### PR TITLE
Allow destructuring property arrow function, closes #194

### DIFF
--- a/src/tests/suite/colorize-fixtures/theme-function.js
+++ b/src/tests/suite/colorize-fixtures/theme-function.js
@@ -1,0 +1,4 @@
+const StyledDiv = styled.div(({theme}) => `
+    color: ${theme.primary.main};
+    height: 12px;
+`)

--- a/src/tests/suite/colorize-results/theme-function_js.json
+++ b/src/tests/suite/colorize-results/theme-function_js.json
@@ -67,7 +67,7 @@
 	},
 	{
 		"c": "styled",
-		"t": "source.js meta.var.expr.js variable.other.object.ts",
+		"t": "source.js meta.var.expr.js meta.function-call.ts variable.other.object.ts",
 		"r": {
 			"dark_plus": "variable: #9CDCFE",
 			"light_plus": "variable: #001080",
@@ -78,7 +78,7 @@
 	},
 	{
 		"c": ".",
-		"t": "source.js meta.var.expr.js punctuation.accessor.ts",
+		"t": "source.js meta.var.expr.js meta.function-call.ts punctuation.accessor.ts",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -89,13 +89,13 @@
 	},
 	{
 		"c": "div",
-		"t": "source.js meta.var.expr.js variable.other.property.ts",
+		"t": "source.js meta.var.expr.js meta.function-call.ts entity.name.function.ts",
 		"r": {
-			"dark_plus": "variable: #9CDCFE",
-			"light_plus": "variable: #001080",
+			"dark_plus": "entity.name.function: #DCDCAA",
+			"light_plus": "entity.name.function: #795E26",
 			"dark_vs": "default: #D4D4D4",
 			"light_vs": "default: #000000",
-			"hc_black": "variable: #9CDCFE"
+			"hc_black": "entity.name.function: #DCDCAA"
 		}
 	},
 	{

--- a/src/tests/suite/colorize-results/theme-function_js.json
+++ b/src/tests/suite/colorize-results/theme-function_js.json
@@ -1,0 +1,343 @@
+[
+	{
+		"c": "const",
+		"t": "source.js meta.var.expr.js storage.type.js",
+		"r": {
+			"dark_plus": "storage.type: #569CD6",
+			"light_plus": "storage.type: #0000FF",
+			"dark_vs": "storage.type: #569CD6",
+			"light_vs": "storage.type: #0000FF",
+			"hc_black": "storage.type: #569CD6"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.js meta.var.expr.js",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "StyledDiv",
+		"t": "source.js meta.var.expr.js meta.var-single-variable.expr.js meta.definition.variable.js variable.other.constant.js",
+		"r": {
+			"dark_plus": "variable.other.constant: #4FC1FF",
+			"light_plus": "variable.other.constant: #0070C1",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "variable: #9CDCFE"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.js meta.var.expr.js meta.var-single-variable.expr.js",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "=",
+		"t": "source.js meta.var.expr.js keyword.operator.assignment.js",
+		"r": {
+			"dark_plus": "keyword.operator: #D4D4D4",
+			"light_plus": "keyword.operator: #000000",
+			"dark_vs": "keyword.operator: #D4D4D4",
+			"light_vs": "keyword.operator: #000000",
+			"hc_black": "keyword.operator: #D4D4D4"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.js meta.var.expr.js",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "styled",
+		"t": "source.js meta.var.expr.js variable.other.object.ts",
+		"r": {
+			"dark_plus": "variable: #9CDCFE",
+			"light_plus": "variable: #001080",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "variable: #9CDCFE"
+		}
+	},
+	{
+		"c": ".",
+		"t": "source.js meta.var.expr.js punctuation.accessor.ts",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "div",
+		"t": "source.js meta.var.expr.js variable.other.property.ts",
+		"r": {
+			"dark_plus": "variable: #9CDCFE",
+			"light_plus": "variable: #001080",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "variable: #9CDCFE"
+		}
+	},
+	{
+		"c": "(({theme}) => `",
+		"t": "source.js meta.var.expr.js punctuation.definition.string.template.begin.js string.template.js",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.js meta.var.expr.js source.css.scss",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "color",
+		"t": "source.js meta.var.expr.js source.css.scss meta.property-name.scss support.type.property-name.css",
+		"r": {
+			"dark_plus": "support.type.property-name: #9CDCFE",
+			"light_plus": "support.type.property-name: #FF0000",
+			"dark_vs": "support.type.property-name: #9CDCFE",
+			"light_vs": "support.type.property-name: #FF0000",
+			"hc_black": "support.type.property-name: #D4D4D4"
+		}
+	},
+	{
+		"c": ":",
+		"t": "source.js meta.var.expr.js source.css.scss punctuation.separator.key-value.scss",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.js meta.var.expr.js source.css.scss",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "${",
+		"t": "source.js meta.var.expr.js source.css.scss meta.property-value.scss variable.interpolation.scss punctuation.definition.interpolation.begin.bracket.curly.scss punctuation.definition.template-expression.begin.js",
+		"r": {
+			"dark_plus": "punctuation.definition.template-expression.begin: #569CD6",
+			"light_plus": "punctuation.definition.template-expression.begin: #0000FF",
+			"dark_vs": "punctuation.definition.template-expression.begin: #569CD6",
+			"light_vs": "punctuation.definition.template-expression.begin: #0000FF",
+			"hc_black": "punctuation.definition.template-expression.begin: #569CD6"
+		}
+	},
+	{
+		"c": "theme",
+		"t": "source.js meta.var.expr.js source.css.scss meta.property-value.scss variable.interpolation.scss meta.embedded.line.ts variable.other.object.ts",
+		"r": {
+			"dark_plus": "variable: #9CDCFE",
+			"light_plus": "variable: #001080",
+			"dark_vs": "meta.embedded: #D4D4D4",
+			"light_vs": "meta.embedded: #000000",
+			"hc_black": "variable: #9CDCFE"
+		}
+	},
+	{
+		"c": ".",
+		"t": "source.js meta.var.expr.js source.css.scss meta.property-value.scss variable.interpolation.scss meta.embedded.line.ts punctuation.accessor.ts",
+		"r": {
+			"dark_plus": "meta.embedded: #D4D4D4",
+			"light_plus": "meta.embedded: #000000",
+			"dark_vs": "meta.embedded: #D4D4D4",
+			"light_vs": "meta.embedded: #000000",
+			"hc_black": "meta.embedded: #FFFFFF"
+		}
+	},
+	{
+		"c": "primary",
+		"t": "source.js meta.var.expr.js source.css.scss meta.property-value.scss variable.interpolation.scss meta.embedded.line.ts variable.other.object.property.ts",
+		"r": {
+			"dark_plus": "variable: #9CDCFE",
+			"light_plus": "variable: #001080",
+			"dark_vs": "meta.embedded: #D4D4D4",
+			"light_vs": "meta.embedded: #000000",
+			"hc_black": "variable: #9CDCFE"
+		}
+	},
+	{
+		"c": ".",
+		"t": "source.js meta.var.expr.js source.css.scss meta.property-value.scss variable.interpolation.scss meta.embedded.line.ts punctuation.accessor.ts",
+		"r": {
+			"dark_plus": "meta.embedded: #D4D4D4",
+			"light_plus": "meta.embedded: #000000",
+			"dark_vs": "meta.embedded: #D4D4D4",
+			"light_vs": "meta.embedded: #000000",
+			"hc_black": "meta.embedded: #FFFFFF"
+		}
+	},
+	{
+		"c": "main",
+		"t": "source.js meta.var.expr.js source.css.scss meta.property-value.scss variable.interpolation.scss meta.embedded.line.ts variable.other.property.ts",
+		"r": {
+			"dark_plus": "variable: #9CDCFE",
+			"light_plus": "variable: #001080",
+			"dark_vs": "meta.embedded: #D4D4D4",
+			"light_vs": "meta.embedded: #000000",
+			"hc_black": "variable: #9CDCFE"
+		}
+	},
+	{
+		"c": "}",
+		"t": "source.js meta.var.expr.js source.css.scss meta.property-value.scss variable.interpolation.scss punctuation.definition.interpolation.end.bracket.curly.scss punctuation.definition.template-expression.end.js",
+		"r": {
+			"dark_plus": "punctuation.definition.template-expression.end: #569CD6",
+			"light_plus": "punctuation.definition.template-expression.end: #0000FF",
+			"dark_vs": "punctuation.definition.template-expression.end: #569CD6",
+			"light_vs": "punctuation.definition.template-expression.end: #0000FF",
+			"hc_black": "punctuation.definition.template-expression.end: #569CD6"
+		}
+	},
+	{
+		"c": ";",
+		"t": "source.js meta.var.expr.js source.css.scss punctuation.terminator.rule.scss",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.js meta.var.expr.js source.css.scss",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "background-color",
+		"t": "source.js meta.var.expr.js source.css.scss meta.property-name.scss support.type.property-name.css",
+		"r": {
+			"dark_plus": "support.type.property-name: #9CDCFE",
+			"light_plus": "support.type.property-name: #FF0000",
+			"dark_vs": "support.type.property-name: #9CDCFE",
+			"light_vs": "support.type.property-name: #FF0000",
+			"hc_black": "support.type.property-name: #D4D4D4"
+		}
+	},
+	{
+		"c": ":",
+		"t": "source.js meta.var.expr.js source.css.scss punctuation.separator.key-value.scss",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.js meta.var.expr.js source.css.scss",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "#",
+		"t": "source.js meta.var.expr.js source.css.scss meta.property-value.scss constant.other.color.rgb-value.hex.css punctuation.definition.constant.css",
+		"r": {
+			"dark_plus": "constant.other.color.rgb-value: #CE9178",
+			"light_plus": "constant.other.color.rgb-value: #0451A5",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "constant.other.color.rgb-value: #0451A5",
+			"hc_black": "constant.other.color.rgb-value: #CE9178"
+		}
+	},
+	{
+		"c": "ffffff",
+		"t": "source.js meta.var.expr.js source.css.scss meta.property-value.scss constant.other.color.rgb-value.hex.css",
+		"r": {
+			"dark_plus": "constant.other.color.rgb-value: #CE9178",
+			"light_plus": "constant.other.color.rgb-value: #0451A5",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "constant.other.color.rgb-value: #0451A5",
+			"hc_black": "constant.other.color.rgb-value: #CE9178"
+		}
+	},
+	{
+		"c": ";",
+		"t": "source.js meta.var.expr.js source.css.scss punctuation.terminator.rule.scss",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "`",
+		"t": "source.js meta.var.expr.js punctuation.definition.string.template.end.js string.template.js",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": ")",
+		"t": "source.js meta.var.expr.js",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	}
+]

--- a/src/tests/suite/colorize-results/theme-function_js.json
+++ b/src/tests/suite/colorize-results/theme-function_js.json
@@ -99,7 +99,106 @@
 		}
 	},
 	{
-		"c": "(({theme}) => `",
+		"c": "(",
+		"t": "source.js meta.var.expr.js meta.brace.round.ts",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "(",
+		"t": "source.js meta.var.expr.js meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.begin.ts",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "{",
+		"t": "source.js meta.var.expr.js meta.arrow.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts punctuation.definition.binding-pattern.object.ts",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "theme",
+		"t": "source.js meta.var.expr.js meta.arrow.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts variable.parameter.ts",
+		"r": {
+			"dark_plus": "variable: #9CDCFE",
+			"light_plus": "variable: #001080",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "variable: #9CDCFE"
+		}
+	},
+	{
+		"c": "}",
+		"t": "source.js meta.var.expr.js meta.arrow.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts punctuation.definition.binding-pattern.object.ts",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": ")",
+		"t": "source.js meta.var.expr.js meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.end.ts",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.js meta.var.expr.js meta.arrow.ts",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "=>",
+		"t": "source.js meta.var.expr.js meta.arrow.ts storage.type.function.arrow.ts",
+		"r": {
+			"dark_plus": "storage.type: #569CD6",
+			"light_plus": "storage.type: #0000FF",
+			"dark_vs": "storage.type: #569CD6",
+			"light_vs": "storage.type: #0000FF",
+			"hc_black": "storage.type: #569CD6"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.js meta.var.expr.js meta.arrow.ts",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "`",
 		"t": "source.js meta.var.expr.js punctuation.definition.string.template.begin.js string.template.js",
 		"r": {
 			"dark_plus": "string: #CE9178",
@@ -253,7 +352,7 @@
 		}
 	},
 	{
-		"c": "background-color",
+		"c": "height",
 		"t": "source.js meta.var.expr.js source.css.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
@@ -286,25 +385,25 @@
 		}
 	},
 	{
-		"c": "#",
-		"t": "source.js meta.var.expr.js source.css.scss meta.property-value.scss constant.other.color.rgb-value.hex.css punctuation.definition.constant.css",
+		"c": "12",
+		"t": "source.js meta.var.expr.js source.css.scss meta.property-value.scss constant.numeric.css",
 		"r": {
-			"dark_plus": "constant.other.color.rgb-value: #CE9178",
-			"light_plus": "constant.other.color.rgb-value: #0451A5",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "constant.other.color.rgb-value: #0451A5",
-			"hc_black": "constant.other.color.rgb-value: #CE9178"
+			"dark_plus": "constant.numeric: #B5CEA8",
+			"light_plus": "constant.numeric: #098658",
+			"dark_vs": "constant.numeric: #B5CEA8",
+			"light_vs": "constant.numeric: #098658",
+			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
 	{
-		"c": "ffffff",
-		"t": "source.js meta.var.expr.js source.css.scss meta.property-value.scss constant.other.color.rgb-value.hex.css",
+		"c": "px",
+		"t": "source.js meta.var.expr.js source.css.scss meta.property-value.scss constant.numeric.css keyword.other.unit.px.css",
 		"r": {
-			"dark_plus": "constant.other.color.rgb-value: #CE9178",
-			"light_plus": "constant.other.color.rgb-value: #0451A5",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "constant.other.color.rgb-value: #0451A5",
-			"hc_black": "constant.other.color.rgb-value: #CE9178"
+			"dark_plus": "keyword.other.unit: #B5CEA8",
+			"light_plus": "keyword.other.unit: #098658",
+			"dark_vs": "keyword.other.unit: #B5CEA8",
+			"light_vs": "keyword.other.unit: #098658",
+			"hc_black": "keyword.other.unit: #B5CEA8"
 		}
 	},
 	{
@@ -331,7 +430,7 @@
 	},
 	{
 		"c": ")",
-		"t": "source.js meta.var.expr.js",
+		"t": "source.js meta.var.expr.js meta.brace.round.js source.js",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",

--- a/syntaxes/styled-components.json
+++ b/syntaxes/styled-components.json
@@ -4,7 +4,7 @@
   "patterns": [
     {
       "contentName": "source.css.scss",
-      "begin": "(?:([\\s\\S][sS][tT][yY][lL][eE][dD](?:<.+>(?=\\())?(?:\\.[_$[:alpha:]][_$[:alnum:]]*|\\s*\\(['\"][_$[:alpha:]][_$[:alnum:]]*['\"]\\)|\\s*\\((.+)\\))(?:\\s*<.+>)?)|(css|keyframes|injectGlobal|createGlobalStyle|stylesheet)(<.+>)?)\\s*(`|\\(\\(\\{\\w+\\}\\)\\s*=>\\s*`)",
+      "begin": "(?:([\\s\\S][sS][tT][yY][lL][eE][dD](?:<.+>(?=\\())?(?:\\.[_$[:alpha:]][_$[:alnum:]]*|\\s*\\(['\"][_$[:alpha:]][_$[:alnum:]]*['\"]\\)|\\s*\\((.+)\\))(?:\\s*<.+>)?)|(css|keyframes|injectGlobal|createGlobalStyle|stylesheet)(<.+>)?)\\s*(\\(\\(\\{?[\\w,\\:\\s]+\\}?\\)\\s*=>\\s*)?(`)",
       "beginCaptures": {
         "1": {
           "patterns": [
@@ -31,13 +31,23 @@
           ]
         },
         "5": {
+          "patterns": [
+            {
+              "include": "source.ts#expression"
+            }
+          ]
+        },
+        "6": {
           "name": "punctuation.definition.string.template.begin.js string.template.js"
         }
       },
-      "end": "`",
+      "end": "(`)(\\))?",
       "endCaptures": {
-        "0": {
+        "1": {
           "name": "punctuation.definition.string.template.end.js string.template.js"
+        },
+        "0": {
+          "name": "meta.brace.round.js source.js"
         }
       },
       "patterns": [

--- a/syntaxes/styled-components.json
+++ b/syntaxes/styled-components.json
@@ -4,7 +4,7 @@
   "patterns": [
     {
       "contentName": "source.css.scss",
-      "begin": "(?:([\\s\\S][sS][tT][yY][lL][eE][dD](?:<.+>(?=\\())?(?:\\.[_$[:alpha:]][_$[:alnum:]]*|\\s*\\(['\"][_$[:alpha:]][_$[:alnum:]]*['\"]\\)|\\s*\\((.+)\\))(?:\\s*<.+>)?)|(css|keyframes|injectGlobal|createGlobalStyle|stylesheet)(<.+>)?)\\s*(`)",
+      "begin": "(?:([\\s\\S][sS][tT][yY][lL][eE][dD](?:<.+>(?=\\())?(?:\\.[_$[:alpha:]][_$[:alnum:]]*|\\s*\\(['\"][_$[:alpha:]][_$[:alnum:]]*['\"]\\)|\\s*\\((.+)\\))(?:\\s*<.+>)?)|(css|keyframes|injectGlobal|createGlobalStyle|stylesheet)(<.+>)?)\\s*(`|\\(\\(\\{\\w+\\}\\)\\s*=>\\s*`)",
       "beginCaptures": {
         "1": {
           "patterns": [

--- a/syntaxes/styled-components.json
+++ b/syntaxes/styled-components.json
@@ -4,7 +4,7 @@
   "patterns": [
     {
       "contentName": "source.css.scss",
-      "begin": "(?:([\\s\\S][sS][tT][yY][lL][eE][dD](?:<.+>(?=\\())?(?:\\.[_$[:alpha:]][_$[:alnum:]]*|\\s*\\(['\"][_$[:alpha:]][_$[:alnum:]]*['\"]\\)|\\s*\\((.+)\\))(?:\\s*<.+>)?)|(css|keyframes|injectGlobal|createGlobalStyle|stylesheet)(<.+>)?)\\s*(\\(\\(\\{?[\\w,\\:\\s]+\\}?\\)\\s*=>\\s*)?(`)",
+      "begin": "(?:([\\s\\S][sS][tT][yY][lL][eE][dD](?:<.+>(?=\\())?(?:\\.[_$[:alpha:]][_$[:alnum:]]*|\\s*\\(['\"][_$[:alpha:]][_$[:alnum:]]*['\"]\\)|\\s*\\((.+)\\))(?:\\s*<.+>)?\\(?)|(css|keyframes|injectGlobal|createGlobalStyle|stylesheet)(<.+>)?)\\s*(\\([\\{\\}\\w,\\:\\s]+?\\)\\s*=>\\s*)?(`)",
       "beginCaptures": {
         "1": {
           "patterns": [

--- a/syntaxes/styled-components.json
+++ b/syntaxes/styled-components.json
@@ -46,7 +46,7 @@
         "1": {
           "name": "punctuation.definition.string.template.end.js string.template.js"
         },
-        "0": {
+        "2": {
           "name": "meta.brace.round.js source.js"
         }
       },


### PR DESCRIPTION
This PR adds support for nesting functions inside a styled components function, closing #194

Before
![image](https://user-images.githubusercontent.com/841788/101162180-e47eb400-3629-11eb-9d45-bcd2b0edbf39.png)
After
![image](https://user-images.githubusercontent.com/841788/101162212-f2ccd000-3629-11eb-8ebc-e551eb658f75.png)

There might still be cases this doesn't catch, e.g. it only supports arrow functions, but I think it is a good start.