### PR TITLE
npm script postinstall -> prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "node ./src/tests/runTests.js",
     "watch": "webpack --mode development --watch",
     "vscode:prepublish": "webpack --mode production",
-    "postinstall": "husky install"
+    "prepare": "husky install"
   },
   "activationEvents": [
     "onLanguage:typescriptreact",


### PR DESCRIPTION
This PR has come up before (see #203). Using `prepare` instead of `postinstall` enables others to use `vscode-styled-components` as a dependency in downstream projects. In my case [that's a blog](https://github.com/janosh/blog/blob/master/package.json#L61) with syntax highlighting for styled components.