### PR TITLE
Add installation notes about tab completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ It should be the top result.
 
 [[Source](https://marketplace.visualstudio.com/items?itemName=jpoissonnier.vscode-styled-components)]
 
+**Be sure to include `"emmet.triggerExpansionOnTab": true` in your VSCode settings to enable tab completion.** More settings and instructions can be found [here](https://code.visualstudio.com/docs/editor/emmet).
+
 ## Features
 
 - Syntax highlighting for styled components in JavaScript and TypeScript.


### PR DESCRIPTION
It's easy to overlook the documentation for this plugin since people usually expect to see it in the README.
Fixes https://github.com/styled-components/vscode-styled-components/issues/72