### PR TITLE
Add support for double parens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.6.0 (N/A)
 
 - Updated typescript-styled-plugin to v0.17
+- Improved Syntax support
 - Added support for keyframes
 - Updated colorProvider to support alpha values on hex colors
 - Adds a colon or semicolon on Enter. Also moves the cursor to the middle of a () function [284](https://github.com/styled-components/vscode-styled-components/pull/284)

--- a/syntaxes/styled-components.json
+++ b/syntaxes/styled-components.json
@@ -4,7 +4,7 @@
   "patterns": [
     {
       "contentName": "source.css.scss",
-      "begin": "(?:(?:([\\s\\S][sS][tT][yY][lL][eE][dD](?:<.+>(?=\\())?(?:\\.[_$[:alpha:]][_$[:alnum:]]*|\\s*\\(['\"][_$[:alpha:]][_$[:alnum:]]*['\"]\\)|\\s*\\((.+)\\))(?:\\s*<.+>)?\\(?)|(css|keyframes|injectGlobal|createGlobalStyle|stylesheet)(<.+>)?)\\s*(\\([\\{\\}\\w,\\:\\s]+?\\)\\s*=>\\s*)?(`))|}>(`)",
+      "begin": "(?:(?:([\\s\\S][sS][tT][yY][lL][eE][dD](?:<.+>(?=\\())?(?:\\.[_$[:alpha:]][_$[:alnum:]]*|\\s*\\(['\"][_$[:alpha:]][_$[:alnum:]]*['\"]\\)|\\s*\\((.+)\\))(?:\\s*<.+>)?\\(?)|(css|keyframes|injectGlobal|createGlobalStyle|stylesheet)(<.+>)?)\\s*(\\([\\{\\}\\w,\\:\\s]+?\\)\\s*=>\\s*)?(`))|(?:}>|\\)\\))(`)",
       "beginCaptures": {
         "1": {
           "patterns": [


### PR DESCRIPTION
Creates a non-capturing group which checks for both `}>` or `))` followed by a `

fixes #169
fixes #124
fixes #154
fixes #174