### PR TITLE
Add support for highlighting :focus-visible and :user-invalid pseudoclasses

### DIFF
--- a/syntaxes/css.styled.json
+++ b/syntaxes/css.styled.json
@@ -1023,7 +1023,7 @@
       }
     },
     "selector_custom": {
-      "match": "\\b([a-zA-Z0-9]+(-[a-zA-Z0-9]+)+)(?=\\.|\\s++[^:]|\\s*[,\\[{]|:(link|visited|hover|active|focus|target|lang|disabled|enabled|checked|indeterminate|root|nth-(child|last-child|of-type|last-of-type)|first-child|last-child|first-of-type|last-of-type|only-child|only-of-type|empty|not|valid|invalid)(\\([0-9A-Za-z]*\\))?)",
+      "match": "\\b([a-zA-Z0-9]+(-[a-zA-Z0-9]+)+)(?=\\.|\\s++[^:]|\\s*[,\\[{]|:(link|visited|hover|active|focus|focus-visible|target|lang|disabled|enabled|checked|indeterminate|root|nth-(child|last-child|of-type|last-of-type)|first-child|last-child|first-of-type|last-of-type|only-child|only-of-type|empty|not|valid|invalid|user-invalid)(\\([0-9A-Za-z]*\\))?)",
       "name": "entity.name.tag.custom.scss"
     },
     "selector_id": {


### PR DESCRIPTION
Maybe closes #288? 