### PR TITLE
Guard insert colon with when clause.

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
       {
         "command": "extension.insertColonOrSemiColon",
         "key": "enter",
-        "when": "suggestWidgetVisible && textInputFocus && editorLangId =~ /javascript|typescript|javascriptreact|typescriptreact/"
+        "when": "suggestWidgetVisible && textInputFocus && editorLangId =~ /javascript|typescript|javascriptreact|typescriptreact/ && config.editor.acceptSuggestionOnEnter != 'off'"
       }
     ]
   },

--- a/src/insertColonCommand.ts
+++ b/src/insertColonCommand.ts
@@ -11,12 +11,6 @@ const properties = cssDataProvider.provideProperties();
 export const enterKeyEvent = commands.registerCommand(
   "extension.insertColonOrSemiColon",
   async () => {
-    // Respect user's acceptSuggestionOnEnter configuration
-    if (acceptSuggestionOnEnter === "off") {
-      commands.executeCommand("cursorDown");
-      return;
-    }
-
     await commands.executeCommand("acceptSelectedSuggestion");
     const editor = window.activeTextEditor;
 

--- a/src/insertColonCommand.ts
+++ b/src/insertColonCommand.ts
@@ -1,9 +1,5 @@
-import { commands, window, workspace } from "vscode";
+import { commands, window } from "vscode";
 import { getDefaultCSSDataProvider } from "vscode-css-languageservice";
-
-const acceptSuggestionOnEnter = workspace
-  .getConfiguration("editor")
-  .get("acceptSuggestionOnEnter");
 
 const cssDataProvider = getDefaultCSSDataProvider();
 const properties = cssDataProvider.provideProperties();


### PR DESCRIPTION
This change tweaks the way `insertColonOrSemicolon` avoids clobbering `editor.acceptSuggestionOnEnter`. Executing `cursorDown` led to some wonky behavior for me. It felt counterintuitive that <kbd>Enter</kbd> didn't insert a newline---particularly with autoclosing enabled, as this input...

```ts
export const Comp = styled.div`|`
```

...followed by <kbd>Enter</kbd>, produced this:

```ts
export const Comp = styled.div``
|
```

With this change, the command will simply not bind to <kbd>Enter</kbd> when `acceptSuggestionOnEnter` is disabled.