### PR TITLE
Support multiple percentages in keyframes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## TBD
 
-- Support multiple percentages in keyframes
+- Support multiple percentages in keyframes [#345](https://github.com/styled-components/vscode-styled-components/pull/345)
 
 ## 1.7.0 (09-12-2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Release Notes
 
-## TBD
+## 1.7.3
 
-- Support multiple percentages in keyframes [#345](https://github.com/styled-components/vscode-styled-components/pull/345)
+- Support multiple percentages in keyframes. [#345](https://github.com/styled-components/vscode-styled-components/pull/345)
+
+## 1.7.2
+
+- Small fixes
 
 ## 1.7.0 (09-12-2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## TBD
+
+- Support multiple percentages in keyframes
+
 ## 1.7.0 (09-12-2021)
 
 PLEASE READ: Styled Components has moved! Make sure you're downloading it from here:

--- a/src/tests/suite/colorize-fixtures/keyframes.js
+++ b/src/tests/suite/colorize-fixtures/keyframes.js
@@ -6,3 +6,7 @@ const rotate360 = keyframes`
         transform: rotate(1turn);
     }
 `;
+
+const something = keyframes`
+    68%, 72% { left: 50px; }
+`;

--- a/src/tests/suite/colorize-results/keyframes_js.json
+++ b/src/tests/suite/colorize-results/keyframes_js.json
@@ -460,5 +460,280 @@
 			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
+	},
+	{
+		"c": "const",
+		"t": "source.js meta.var.expr.ts storage.type.ts",
+		"r": {
+			"dark_plus": "storage.type: #569CD6",
+			"light_plus": "storage.type: #0000FF",
+			"dark_vs": "storage.type: #569CD6",
+			"light_vs": "storage.type: #0000FF",
+			"hc_black": "storage.type: #569CD6"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.js meta.var.expr.ts",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "something",
+		"t": "source.js meta.var.expr.ts meta.var-single-variable.expr.ts meta.definition.variable.ts variable.other.constant.ts",
+		"r": {
+			"dark_plus": "variable.other.constant: #4FC1FF",
+			"light_plus": "variable.other.constant: #0070C1",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "variable: #9CDCFE"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.js meta.var.expr.ts meta.var-single-variable.expr.ts",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "=",
+		"t": "source.js meta.var.expr.ts keyword.operator.assignment.ts",
+		"r": {
+			"dark_plus": "keyword.operator: #D4D4D4",
+			"light_plus": "keyword.operator: #000000",
+			"dark_vs": "keyword.operator: #D4D4D4",
+			"light_vs": "keyword.operator: #000000",
+			"hc_black": "keyword.operator: #D4D4D4"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.js meta.var.expr.ts",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "keyframes",
+		"t": "source.js entity.name.function.tagged-template.js variable.other.property.js",
+		"r": {
+			"dark_plus": "variable: #9CDCFE",
+			"light_plus": "variable: #001080",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "variable: #9CDCFE"
+		}
+	},
+	{
+		"c": "`",
+		"t": "source.js punctuation.definition.string.template.begin.js string.template.js",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.js source.css.scss",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "68%",
+		"t": "source.js source.css.scss entity.other.attribute-name.scss",
+		"r": {
+			"dark_plus": "entity.other.attribute-name.scss: #D7BA7D",
+			"light_plus": "entity.other.attribute-name.scss: #800000",
+			"dark_vs": "entity.other.attribute-name.scss: #D7BA7D",
+			"light_vs": "entity.other.attribute-name.scss: #800000",
+			"hc_black": "entity.other.attribute-name.scss: #D7BA7D"
+		}
+	},
+	{
+		"c": ", ",
+		"t": "source.js source.css.scss",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "72%",
+		"t": "source.js source.css.scss entity.other.attribute-name.scss",
+		"r": {
+			"dark_plus": "entity.other.attribute-name.scss: #D7BA7D",
+			"light_plus": "entity.other.attribute-name.scss: #800000",
+			"dark_vs": "entity.other.attribute-name.scss: #D7BA7D",
+			"light_vs": "entity.other.attribute-name.scss: #800000",
+			"hc_black": "entity.other.attribute-name.scss: #D7BA7D"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.js source.css.scss",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "{",
+		"t": "source.js source.css.scss meta.property-list.scss punctuation.section.property-list.begin.bracket.curly.scss",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.js source.css.scss meta.property-list.scss",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "left",
+		"t": "source.js source.css.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
+		"r": {
+			"dark_plus": "support.type.property-name: #9CDCFE",
+			"light_plus": "support.type.property-name: #FF0000",
+			"dark_vs": "support.type.property-name: #9CDCFE",
+			"light_vs": "support.type.property-name: #FF0000",
+			"hc_black": "support.type.property-name: #D4D4D4"
+		}
+	},
+	{
+		"c": ":",
+		"t": "source.js source.css.scss meta.property-list.scss punctuation.separator.key-value.scss",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.js source.css.scss meta.property-list.scss",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "50",
+		"t": "source.js source.css.scss meta.property-list.scss meta.property-value.scss constant.numeric.css",
+		"r": {
+			"dark_plus": "constant.numeric: #B5CEA8",
+			"light_plus": "constant.numeric: #098658",
+			"dark_vs": "constant.numeric: #B5CEA8",
+			"light_vs": "constant.numeric: #098658",
+			"hc_black": "constant.numeric: #B5CEA8"
+		}
+	},
+	{
+		"c": "px",
+		"t": "source.js source.css.scss meta.property-list.scss meta.property-value.scss constant.numeric.css keyword.other.unit.px.css",
+		"r": {
+			"dark_plus": "keyword.other.unit: #B5CEA8",
+			"light_plus": "keyword.other.unit: #098658",
+			"dark_vs": "keyword.other.unit: #B5CEA8",
+			"light_vs": "keyword.other.unit: #098658",
+			"hc_black": "keyword.other.unit: #B5CEA8"
+		}
+	},
+	{
+		"c": ";",
+		"t": "source.js source.css.scss meta.property-list.scss punctuation.terminator.rule.scss",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.js source.css.scss meta.property-list.scss",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "}",
+		"t": "source.js source.css.scss meta.property-list.scss punctuation.section.property-list.end.bracket.curly.scss",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "`",
+		"t": "source.js punctuation.definition.string.template.end.js string.template.js",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": ";",
+		"t": "source.js punctuation.terminator.statement.js",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
 	}
 ]

--- a/syntaxes/styled-components.json
+++ b/syntaxes/styled-components.json
@@ -303,21 +303,24 @@
       },
       "patterns": [
         {
-          "patterns": [
-            {
-              "match": "\\b(?:(?:100|[1-9]\\d|\\d)%|from|to)(?=\\s*{)",
+          "captures": {
+            "1": {
               "name": "entity.other.attribute-name.scss"
             },
-            {
-              "include": "source.css.styled#interpolation"
-            },
-            {
-              "include": "source.css.styled#property_list"
-            },
-            {
-              "include": "source.css.styled#rules"
+            "2": {
+              "name": "entity.other.attribute-name.scss"
             }
-          ]
+          },
+          "match": "(?xi)\n(?<![\\w-]) (from|to) (?![\\w-])         # Keywords for 0% | 100%\n|\n([-+]?(?:\\d+(?:\\.\\d+)?|\\.\\d+)%)     # Percentile value"
+        },
+        {
+          "include": "source.css.styled#interpolation"
+        },
+        {
+          "include": "source.css.styled#property_list"
+        },
+        {
+          "include": "source.css.styled#rules"
         }
       ]
     },


### PR DESCRIPTION
Keyframes CSS updated from https://github.com/microsoft/vscode/blob/9efc116de0ea4998616ebe3b17ee5b92f7dc1161/extensions/css/syntaxes/css.tmLanguage.json#L439-L449

The native CSS styles don't highlight the percentages, so I couldn't replace this block with the CSS version. Instead I copied it but kept the naming of the attributes as before to keep the colouring of the percentages.

Test:
Before only `68%` was highlighted, now both percentages should be highlighted