### PR TITLE
Add support for `@container` queries by updating the CSS language service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 1.7.9 (11-12-2023)
+
+- Add support for `@container` queries
+
 ## 1.7.8 (03-04-2023)
 
 - Bug fix, update typescript styled plugin to re-enable auto completion

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ If however you believe this property is standard and thus missing you can raise 
 ### Intellisense is not working!
 
 #### It hasn't worked since updating to v1.7.8!
+
 This is due to a clash between TypeScript 5.0.0 and this extension. When VSCode released March 2023 that had TypeScript 5.X set by default which 1.7.8 supports but lower versions don't.
 So, if you're not getting intellisense its most likely because you've updated the extension but haven't updated your version of TypeScript yet. The quick option is to downgrade to v1.7.5, the long term option is to migrate to TypeScript 5.X
 See: https://github.com/styled-components/vscode-styled-components/issues/387

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.7.9",
       "license": "MIT",
       "dependencies": {
-        "@styled/typescript-styled-plugin": "^1.0.0",
+        "@styled/typescript-styled-plugin": "^1.0.1",
         "d3-color": "^3.1.0",
         "vscode-css-languageservice": "^6.2.11"
       },
@@ -32,25 +32,25 @@
       }
     },
     "node_modules/@emmetio/abbreviation": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.1.tgz",
-      "integrity": "sha512-QXgYlXZGprqb6aCBJPPWVBN/Jb69khJF73GGJkOk//PoMgSbPGuaHn1hCRolctnzlBHjCIC6Om97Pw46/1A23g==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
+      "integrity": "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==",
       "dependencies": {
-        "@emmetio/scanner": "^1.0.2"
+        "@emmetio/scanner": "^1.0.4"
       }
     },
     "node_modules/@emmetio/css-abbreviation": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.6.tgz",
-      "integrity": "sha512-bvuPogt0OvwcILRg+ZD/oej1H72xwOhUDPWOmhCWLJrZZ8bMTazsWnvw8a8noaaVqUhOE9PsC0tYgGVv5N7fsw==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.8.tgz",
+      "integrity": "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==",
       "dependencies": {
-        "@emmetio/scanner": "^1.0.2"
+        "@emmetio/scanner": "^1.0.4"
       }
     },
     "node_modules/@emmetio/scanner": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.2.tgz",
-      "integrity": "sha512-1ESCGgXRgn1r29hRmz8K0G4Ywr5jDWezMgRnICComBCWmg3znLWU8+tmakuM1og1Vn4W/sauvlABl/oq2pve8w=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.4.tgz",
+      "integrity": "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.15.16",
@@ -85,15 +85,15 @@
       }
     },
     "node_modules/@styled/typescript-styled-plugin": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@styled/typescript-styled-plugin/-/typescript-styled-plugin-1.0.0.tgz",
-      "integrity": "sha512-TGAZrTPPglyzdO6mWyC1QWNN3G2zZHy2/YrPGE2aie06p1MgtyEWc3GXUa5Xkb/pH7ftinX63mbQTipzVjrTRw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@styled/typescript-styled-plugin/-/typescript-styled-plugin-1.0.1.tgz",
+      "integrity": "sha512-4n9uYJiui4hqGIEMvs/u7sfjbs1/84shYt2Fxcm0JQbvUGfuFhtsqVG5y1hSvw5kTwdpIe4rbXMMOwVHcuAh1g==",
       "dependencies": {
-        "@vscode/emmet-helper": "^2.8.6",
+        "@vscode/emmet-helper": "^2.9.2",
         "typescript-template-language-service-decorator": "^2.3.2",
-        "vscode-css-languageservice": "^6.2.4",
-        "vscode-languageserver-textdocument": "^1.0.8",
-        "vscode-languageserver-types": "^3.17.3"
+        "vscode-css-languageservice": "^6.2.11",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-languageserver-types": "^3.17.5"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -152,11 +152,11 @@
       "dev": true
     },
     "node_modules/@vscode/emmet-helper": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/@vscode/emmet-helper/-/emmet-helper-2.8.6.tgz",
-      "integrity": "sha512-IIB8jbiKy37zN8bAIHx59YmnIelY78CGHtThnibD/d3tQOKRY83bYVi9blwmZVUZh6l9nfkYH3tvReaiNxY9EQ==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@vscode/emmet-helper/-/emmet-helper-2.9.2.tgz",
+      "integrity": "sha512-MaGuyW+fa13q3aYsluKqclmh62Hgp0BpKIqS66fCxfOaBcVQ1OnMQxRRgQUYnCkxFISAQlkJ0qWWPyXjro1Qrg==",
       "dependencies": {
-        "emmet": "^2.3.0",
+        "emmet": "^2.4.3",
         "jsonc-parser": "^2.3.0",
         "vscode-languageserver-textdocument": "^1.0.1",
         "vscode-languageserver-types": "^3.15.1",
@@ -512,12 +512,12 @@
       }
     },
     "node_modules/emmet": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.1.tgz",
-      "integrity": "sha512-8rZn/3b0WRT21UeGjQ+bzUqg3up6xBKqRjeWRZA1mrzHokNf4brqPx88XQ53+s9lK2p/pWI2VlTIu1S59OwDtA==",
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.6.tgz",
+      "integrity": "sha512-dJfbdY/hfeTyf/Ef7Y7ubLYzkBvPQ912wPaeVYpAxvFxkEBf/+hJu4H6vhAvFN6HlxqedlfVn2x1S44FfQ97pg==",
       "dependencies": {
-        "@emmetio/abbreviation": "^2.3.1",
-        "@emmetio/css-abbreviation": "^2.1.6"
+        "@emmetio/abbreviation": "^2.3.3",
+        "@emmetio/css-abbreviation": "^2.1.8"
       }
     },
     "node_modules/emoji-regex": {
@@ -1894,25 +1894,25 @@
   },
   "dependencies": {
     "@emmetio/abbreviation": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.1.tgz",
-      "integrity": "sha512-QXgYlXZGprqb6aCBJPPWVBN/Jb69khJF73GGJkOk//PoMgSbPGuaHn1hCRolctnzlBHjCIC6Om97Pw46/1A23g==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
+      "integrity": "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==",
       "requires": {
-        "@emmetio/scanner": "^1.0.2"
+        "@emmetio/scanner": "^1.0.4"
       }
     },
     "@emmetio/css-abbreviation": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.6.tgz",
-      "integrity": "sha512-bvuPogt0OvwcILRg+ZD/oej1H72xwOhUDPWOmhCWLJrZZ8bMTazsWnvw8a8noaaVqUhOE9PsC0tYgGVv5N7fsw==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.8.tgz",
+      "integrity": "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==",
       "requires": {
-        "@emmetio/scanner": "^1.0.2"
+        "@emmetio/scanner": "^1.0.4"
       }
     },
     "@emmetio/scanner": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.2.tgz",
-      "integrity": "sha512-1ESCGgXRgn1r29hRmz8K0G4Ywr5jDWezMgRnICComBCWmg3znLWU8+tmakuM1og1Vn4W/sauvlABl/oq2pve8w=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.4.tgz",
+      "integrity": "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA=="
     },
     "@esbuild/android-arm": {
       "version": "0.15.16",
@@ -1929,15 +1929,15 @@
       "optional": true
     },
     "@styled/typescript-styled-plugin": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@styled/typescript-styled-plugin/-/typescript-styled-plugin-1.0.0.tgz",
-      "integrity": "sha512-TGAZrTPPglyzdO6mWyC1QWNN3G2zZHy2/YrPGE2aie06p1MgtyEWc3GXUa5Xkb/pH7ftinX63mbQTipzVjrTRw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@styled/typescript-styled-plugin/-/typescript-styled-plugin-1.0.1.tgz",
+      "integrity": "sha512-4n9uYJiui4hqGIEMvs/u7sfjbs1/84shYt2Fxcm0JQbvUGfuFhtsqVG5y1hSvw5kTwdpIe4rbXMMOwVHcuAh1g==",
       "requires": {
-        "@vscode/emmet-helper": "^2.8.6",
+        "@vscode/emmet-helper": "^2.9.2",
         "typescript-template-language-service-decorator": "^2.3.2",
-        "vscode-css-languageservice": "^6.2.4",
-        "vscode-languageserver-textdocument": "^1.0.8",
-        "vscode-languageserver-types": "^3.17.3"
+        "vscode-css-languageservice": "^6.2.11",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-languageserver-types": "^3.17.5"
       }
     },
     "@tootallnate/once": {
@@ -1993,11 +1993,11 @@
       "dev": true
     },
     "@vscode/emmet-helper": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/@vscode/emmet-helper/-/emmet-helper-2.8.6.tgz",
-      "integrity": "sha512-IIB8jbiKy37zN8bAIHx59YmnIelY78CGHtThnibD/d3tQOKRY83bYVi9blwmZVUZh6l9nfkYH3tvReaiNxY9EQ==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@vscode/emmet-helper/-/emmet-helper-2.9.2.tgz",
+      "integrity": "sha512-MaGuyW+fa13q3aYsluKqclmh62Hgp0BpKIqS66fCxfOaBcVQ1OnMQxRRgQUYnCkxFISAQlkJ0qWWPyXjro1Qrg==",
       "requires": {
-        "emmet": "^2.3.0",
+        "emmet": "^2.4.3",
         "jsonc-parser": "^2.3.0",
         "vscode-languageserver-textdocument": "^1.0.1",
         "vscode-languageserver-types": "^3.15.1",
@@ -2264,12 +2264,12 @@
       }
     },
     "emmet": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.1.tgz",
-      "integrity": "sha512-8rZn/3b0WRT21UeGjQ+bzUqg3up6xBKqRjeWRZA1mrzHokNf4brqPx88XQ53+s9lK2p/pWI2VlTIu1S59OwDtA==",
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.6.tgz",
+      "integrity": "sha512-dJfbdY/hfeTyf/Ef7Y7ubLYzkBvPQ912wPaeVYpAxvFxkEBf/+hJu4H6vhAvFN6HlxqedlfVn2x1S44FfQ97pg==",
       "requires": {
-        "@emmetio/abbreviation": "^2.3.1",
-        "@emmetio/css-abbreviation": "^2.1.6"
+        "@emmetio/abbreviation": "^2.3.3",
+        "@emmetio/css-abbreviation": "^2.1.8"
       }
     },
     "emoji-regex": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "vscode-styled-components",
-  "version": "1.7.8",
+  "version": "1.7.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-styled-components",
-      "version": "1.7.8",
+      "version": "1.7.9",
       "license": "MIT",
       "dependencies": {
         "@styled/typescript-styled-plugin": "^1.0.0",
         "d3-color": "^3.1.0",
-        "vscode-css-languageservice": "^6.2.1"
+        "vscode-css-languageservice": "^6.2.11"
       },
       "devDependencies": {
         "@types/d3-color": "^3.1.0",
@@ -164,9 +164,9 @@
       }
     },
     "node_modules/@vscode/l10n": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.11.tgz",
-      "integrity": "sha512-ukOMWnCg1tCvT7WnDfsUKQOFDQGsyR5tNgRpwmqi+5/vzU3ghdDXzvIM4IOPdSb3OeSsBNvmSL8nxIVOqi2WXA=="
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.16.tgz",
+      "integrity": "sha512-JT5CvrIYYCrmB+dCana8sUqJEcGB1ZDXNLMQ2+42bW995WmNoenijWMUdZfwmuQUTQcEVVIa2OecZzTYWUW9Cg=="
     },
     "node_modules/@vscode/test-electron": {
       "version": "2.2.0",
@@ -1754,30 +1754,30 @@
       "dev": true
     },
     "node_modules/vscode-css-languageservice": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.2.4.tgz",
-      "integrity": "sha512-9UG0s3Ss8rbaaPZL1AkGzdjrGY8F+P+Ne9snsrvD9gxltDGhsn8C2dQpqQewHrMW37OvlqJoI8sUU2AWDb+qNw==",
+      "version": "6.2.11",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.2.11.tgz",
+      "integrity": "sha512-qn49Wa6K94LnizpVxmlYrcPf1Cb36gq1nNueW0COhi4shylXBzET5wuDbH8ZWQlJD0HM5Mmnn7WE9vQVVs+ULA==",
       "dependencies": {
-        "@vscode/l10n": "^0.0.11",
-        "vscode-languageserver-textdocument": "^1.0.8",
-        "vscode-languageserver-types": "^3.17.3",
-        "vscode-uri": "^3.0.7"
+        "@vscode/l10n": "^0.0.16",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-languageserver-types": "3.17.5",
+        "vscode-uri": "^3.0.8"
       }
     },
     "node_modules/vscode-css-languageservice/node_modules/vscode-uri": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.7.tgz",
-      "integrity": "sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA=="
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
+      "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw=="
     },
     "node_modules/vscode-languageserver-textdocument": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
-      "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q=="
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.11.tgz",
+      "integrity": "sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA=="
     },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
-      "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
     },
     "node_modules/vscode-uri": {
       "version": "2.1.2",
@@ -2005,9 +2005,9 @@
       }
     },
     "@vscode/l10n": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.11.tgz",
-      "integrity": "sha512-ukOMWnCg1tCvT7WnDfsUKQOFDQGsyR5tNgRpwmqi+5/vzU3ghdDXzvIM4IOPdSb3OeSsBNvmSL8nxIVOqi2WXA=="
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.16.tgz",
+      "integrity": "sha512-JT5CvrIYYCrmB+dCana8sUqJEcGB1ZDXNLMQ2+42bW995WmNoenijWMUdZfwmuQUTQcEVVIa2OecZzTYWUW9Cg=="
     },
     "@vscode/test-electron": {
       "version": "2.2.0",
@@ -3086,32 +3086,32 @@
       "dev": true
     },
     "vscode-css-languageservice": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.2.4.tgz",
-      "integrity": "sha512-9UG0s3Ss8rbaaPZL1AkGzdjrGY8F+P+Ne9snsrvD9gxltDGhsn8C2dQpqQewHrMW37OvlqJoI8sUU2AWDb+qNw==",
+      "version": "6.2.11",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.2.11.tgz",
+      "integrity": "sha512-qn49Wa6K94LnizpVxmlYrcPf1Cb36gq1nNueW0COhi4shylXBzET5wuDbH8ZWQlJD0HM5Mmnn7WE9vQVVs+ULA==",
       "requires": {
-        "@vscode/l10n": "^0.0.11",
-        "vscode-languageserver-textdocument": "^1.0.8",
-        "vscode-languageserver-types": "^3.17.3",
-        "vscode-uri": "^3.0.7"
+        "@vscode/l10n": "^0.0.16",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-languageserver-types": "3.17.5",
+        "vscode-uri": "^3.0.8"
       },
       "dependencies": {
         "vscode-uri": {
-          "version": "3.0.7",
-          "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.7.tgz",
-          "integrity": "sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA=="
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
+          "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw=="
         }
       }
     },
     "vscode-languageserver-textdocument": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
-      "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q=="
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.11.tgz",
+      "integrity": "sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA=="
     },
     "vscode-languageserver-types": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
-      "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
     },
     "vscode-uri": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-styled-components",
   "displayName": "vscode-styled-components",
   "description": "Syntax highlighting for styled-components",
-  "version": "1.7.8",
+  "version": "1.7.9",
   "publisher": "styled-components",
   "icon": "logo.png",
   "license": "MIT",
@@ -88,7 +88,7 @@
   "dependencies": {
     "d3-color": "^3.1.0",
     "@styled/typescript-styled-plugin": "^1.0.0",
-    "vscode-css-languageservice": "^6.2.1"
+    "vscode-css-languageservice": "^6.2.11"
   },
   "devDependencies": {
     "@types/d3-color": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   },
   "dependencies": {
     "d3-color": "^3.1.0",
-    "@styled/typescript-styled-plugin": "^1.0.0",
+    "@styled/typescript-styled-plugin": "^1.0.1",
     "vscode-css-languageservice": "^6.2.11"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR updates the CSS language service in order to support `@container` queries.

C.f. https://github.com/microsoft/vscode-css-languageservice/pull/365 and https://github.com/microsoft/vscode-css-languageservice/pull/371

The PR is ready to be published to npm 😉 